### PR TITLE
supercritial steam power cycle system

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,9 +1,9 @@
 // Add your dependencies here
 
 dependencies {
-    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.40.41:dev')
+    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.40.56-dev:dev')
     compile('com.github.GTNewHorizons:StructureLib:1.0.15:dev')
-    compile('com.github.GTNewHorizons:bartworks:0.5.37:dev')
+    compile('com.github.GTNewHorizons:bartworks:0.5.53-pre:dev')
     compile('com.github.GTNewHorizons:NotEnoughItems:2.2.15-GTNH:dev')
     compile('com.github.GTNewHorizons:TecTech:5.0.5.1:dev')
 

--- a/src/main/java/goodgenerator/blocks/tileEntity/CoolantTower.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/CoolantTower.java
@@ -1,0 +1,194 @@
+package goodgenerator.blocks.tileEntity;
+
+import com.github.technus.tectech.thing.metaTileEntity.multi.base.GT_MetaTileEntity_MultiblockBase_EM;
+import com.gtnewhorizon.structurelib.alignment.constructable.IConstructable;
+import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
+import com.gtnewhorizon.structurelib.structure.StructureDefinition;
+import goodgenerator.blocks.tileEntity.base.GT_MetaTileEntity_TooltipMultiBlockBase_EM;
+import goodgenerator.util.DescTextLocalization;
+import gregtech.api.GregTech_API;
+import gregtech.api.enums.Materials;
+import gregtech.api.interfaces.ITexture;
+import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Input;
+import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_Hatch_Output;
+import gregtech.api.render.TextureFactory;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
+import gregtech.api.util.GT_Utility;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
+import static goodgenerator.util.DescTextLocalization.BLUE_PRINT_INFO;
+import static gregtech.api.enums.Textures.BlockIcons.*;
+import static gregtech.api.util.GT_StructureUtility.ofFrame;
+import static gregtech.api.util.GT_StructureUtility.ofHatchAdder;
+
+public class CoolantTower extends GT_MetaTileEntity_TooltipMultiBlockBase_EM implements IConstructable {
+
+    protected IStructureDefinition<CoolantTower> multiDefinition = null;
+    private final int CASING_INDEX = 1542;
+
+    public CoolantTower(int aID, String aName, String aNameRegional) {
+        super(aID, aName, aNameRegional);
+    }
+
+    public CoolantTower(String name) {
+        super(name);
+    }
+
+    @Override
+    public IStructureDefinition<? extends GT_MetaTileEntity_MultiblockBase_EM> getStructure_EM() {
+        if(multiDefinition == null) {
+            multiDefinition = StructureDefinition
+                .<CoolantTower>builder()
+                .addShape(mName,
+                    transpose(new String[][]{
+                        {"           ", "           ", "    BBB    ", "   B   B   ", "  B     B  ", "  B     B  ", "  B     B  ", "   B   B   ", "    BBB    ", "           ", "           "},
+                        {"           ", "           ", "    BBB    ", "   BBBBB   ", "  BB   BB  ", "  BB   BB  ", "  BB   BB  ", "   BBBBB   ", "    BBB    ", "           ", "           "},
+                        {"           ", "           ", "           ", "    BBB    ", "   B   B   ", "   B   B   ", "   B   B   ", "    BBB    ", "           ", "           ", "           "},
+                        {"           ", "           ", "           ", "    BBB    ", "   B   B   ", "   B   B   ", "   B   B   ", "    BBB    ", "           ", "           ", "           "},
+                        {"           ", "           ", "           ", "    BBB    ", "   B   B   ", "   B   B   ", "   B   B   ", "    BBB    ", "           ", "           ", "           "},
+                        {"           ", "           ", "    BBB    ", "   BBBBB   ", "  BB   BB  ", "  BB   BB  ", "  BB   BB  ", "   BBBBB   ", "    BBB    ", "           ", "           "},
+                        {"           ", "           ", "    BBB    ", "   B   B   ", "  B     B  ", "  B     B  ", "  B     B  ", "   B   B   ", "    BBB    ", "           ", "           "},
+                        {"           ", "           ", "    BBB    ", "   B   B   ", "  B     B  ", "  B     B  ", "  B     B  ", "   B   B   ", "    BBB    ", "           ", "           "},
+                        {"           ", "    BBB    ", "   BBBBB   ", "  BB   BB  ", " BB     BB ", " BB     BB ", " BB     BB ", "  BB   BB  ", "   BBBBB   ", "    BBB    ", "           "},
+                        {"           ", "    BBB    ", "   B   B   ", "  B     B  ", " B       B ", " B       B ", " B       B ", "  B     B  ", "   B   B   ", "    BBB    ", "           "},
+                        {"           ", "   BBBBB   ", "  BB   BB  ", " BB     BB ", " B       B ", " B       B ", " B       B ", " BB     BB ", "  BB   BB  ", "   BBBBB   ", "           "},
+                        {"   HH~HH   ", "  HBBBBBH  ", " HB     BH ", "HB       BH", "HB       BH", "HB       BH", "HB       BH", "HB       BH", " HB     BH ", "  HBBBBBH  ", "   HHHHH   "},
+                        {"   CCCCC   ", "  C     C  ", " C       C ", "C         C", "C         C", "C         C", "C         C", "C         C", " C       C ", "  C     C  ", "   CCCCC   "},
+                    })
+                ).addElement('B',
+                    ofBlockAnyMeta(GregTech_API.sBlockConcretes, 8)
+                ).addElement('C',
+                    ofFrame(Materials.TungstenCarbide)
+                ).addElement('H',
+                    ofChain(
+                        ofHatchAdder(
+                            CoolantTower::addIOFluidToMachineList, CASING_INDEX, 1
+                        ),
+                        ofBlockAnyMeta(GregTech_API.sBlockConcretes, 8)
+                    )
+                )
+                .build();
+        }
+        return multiDefinition;
+    }
+
+    public final boolean addIOFluidToMachineList(IGregTechTileEntity aTileEntity, int aBaseCasingIndex) {
+        if (aTileEntity == null) {
+            return false;
+        } else {
+            IMetaTileEntity aMetaTileEntity = aTileEntity.getMetaTileEntity();
+            if (aMetaTileEntity == null) {
+                return false;
+            } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Input) {
+                ((GT_MetaTileEntity_Hatch)aMetaTileEntity).updateTexture(aBaseCasingIndex);
+                return this.mInputHatches.add((GT_MetaTileEntity_Hatch_Input)aMetaTileEntity);
+            } else if (aMetaTileEntity instanceof GT_MetaTileEntity_Hatch_Output) {
+                ((GT_MetaTileEntity_Hatch)aMetaTileEntity).updateTexture(aBaseCasingIndex);
+                return this.mOutputHatches.add((GT_MetaTileEntity_Hatch_Output)aMetaTileEntity);
+            } else {
+                return false;
+            }
+        }
+    }
+
+    @Override
+    public boolean checkMachine_EM(IGregTechTileEntity aBaseMetaTileEntity, ItemStack aStack) {
+        mWrench = true;
+        mScrewdriver = true;
+        mSoftHammer = true;
+        mHardHammer = true;
+        mSolderingTool = true;
+        mCrowbar = true;
+        return structureCheck_EM(mName, 5, 11, 0);
+    }
+
+    @Override
+    protected GT_Multiblock_Tooltip_Builder createTooltip() {
+        final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
+        tt.addMachineType("Coolant Tower")
+            .addInfo("Controller block for the Coolant Tower.")
+            .addInfo("Turn Steam back to Distilled Water.")
+            .addInfo(BLUE_PRINT_INFO)
+            .addSeparator()
+            .addController("Mid of the second layer.")
+            .addInputHatch("Input Hatch", 1)
+            .addOutputHatch("Output Hatch", 1)
+            .toolTipFinisher("Good Generator");
+        return tt;
+    }
+
+    @Override
+    public void construct(ItemStack stackSize, boolean hintsOnly) {
+        structureBuild_EM(mName, 5, 11, 0, stackSize, hintsOnly);
+    }
+
+    @Override
+    public String[] getStructureDescription(ItemStack stackSize) {
+        return DescTextLocalization.addText("CoolantTower.hint", 3);
+    }
+
+    @Override
+    public IMetaTileEntity newMetaEntity(IGregTechTileEntity aTileEntity) {
+        return new CoolantTower(mName);
+    }
+
+    @Override
+    public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTick) {
+        super.onPostTick(aBaseMetaTileEntity, aTick);
+        if (aTick % 72000 == 0) {
+            mWrench = true;
+            mScrewdriver = true;
+            mSoftHammer = true;
+            mHardHammer = true;
+            mSolderingTool = true;
+            mCrowbar = true;
+        }
+    }
+
+    @Override
+    public int getMaxEfficiency(ItemStack aStack) {
+        return 10000;
+    }
+
+    @Override
+    public boolean onRunningTick(ItemStack aStack) {
+        return true;
+    }
+
+    @Override
+    public boolean checkRecipe_EM(ItemStack aStack) {
+        this.mMaxProgresstime = 100;
+        int steam = 0;
+        for (FluidStack steams : getStoredFluids()) {
+            if (GT_Utility.areFluidsEqual(steams, GT_ModHandler.getSteam(1))) {
+                steam += steams.amount;
+            }
+        }
+        steam = steam / 160 * 160;
+        depleteInput(GT_ModHandler.getSteam(steam));
+        addOutput(GT_ModHandler.getDistilledWater(steam / 160));
+        return true;
+    }
+
+    @Override
+    public ITexture[] getTexture(IGregTechTileEntity aBaseMetaTileEntity, byte aSide, byte aFacing, byte aColorIndex, boolean aActive, boolean aRedstone) {
+        if (aSide == aFacing) {
+            if (aActive)
+                return new ITexture[]{
+                    casingTexturePages[12][6],
+                    TextureFactory.builder().addIcon(OVERLAY_FRONT_HEAT_EXCHANGER_ACTIVE).extFacing().build(),
+                    TextureFactory.builder().addIcon(OVERLAY_FRONT_HEAT_EXCHANGER_ACTIVE_GLOW).extFacing().glow().build()};
+            return new ITexture[]{
+                casingTexturePages[12][6],
+                TextureFactory.builder().addIcon(OVERLAY_FRONT_HEAT_EXCHANGER).extFacing().build(),
+                TextureFactory.builder().addIcon(OVERLAY_FRONT_HEAT_EXCHANGER_GLOW).extFacing().glow().build()};
+        }
+        return new ITexture[]{casingTexturePages[12][6]};
+    }
+}

--- a/src/main/java/goodgenerator/crossmod/nei/ExtremeHeatExchangerHandler.java
+++ b/src/main/java/goodgenerator/crossmod/nei/ExtremeHeatExchangerHandler.java
@@ -36,10 +36,11 @@ public class ExtremeHeatExchangerHandler extends GT_NEI_DefaultHandler {
         FluidStack[] Outputs = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mFluidOutputs;
         int Threshold = ((CachedDefaultRecipe) this.arecipes.get(aRecipeIndex)).mRecipe.mSpecialValue;
         drawText(10, 73, StatCollector.translateToLocal("value.extreme_heat_exchanger.0") + " " + GT_Utility.formatNumbers(Inputs[0].amount) + " L/s", -16777216);
-        drawText(10, 83, StatCollector.translateToLocal("value.extreme_heat_exchanger.1") + " " + GT_Utility.formatNumbers(Inputs[1].amount) + " L/s", -16777216);
-        drawText(10, 93, StatCollector.translateToLocal("value.extreme_heat_exchanger.2") + " " + GT_Utility.formatNumbers(Outputs[0].amount) + " L/s", -16777216);
-        drawText(10, 103, StatCollector.translateToLocal("value.extreme_heat_exchanger.3") + " " + GT_Utility.formatNumbers(Outputs[1].amount) + " L/s", -16777216);
-        drawText(10, 113, StatCollector.translateToLocal("value.extreme_heat_exchanger.4") + " " + Threshold + " L/s", -16777216);
+        drawText(10, 83, StatCollector.translateToLocal("value.extreme_heat_exchanger.1"), -16777216);
+        drawText(10, 93, GT_Utility.formatNumbers(Outputs[0].amount / 160) + " L/s", -16777216);
+        drawText(10, 103, StatCollector.translateToLocal("value.extreme_heat_exchanger.2"), -16777216);
+        drawText(10, 113, GT_Utility.formatNumbers(Outputs[1].amount / 160) + " L/s", -16777216);
+        drawText(10, 123, StatCollector.translateToLocal("value.extreme_heat_exchanger.4") + " " + Threshold + " L/s", -16777216);
     }
 
 }

--- a/src/main/java/goodgenerator/loader/Loaders.java
+++ b/src/main/java/goodgenerator/loader/Loaders.java
@@ -23,6 +23,7 @@ import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
 import goodgenerator.util.CrackRecipeAdder;
 import goodgenerator.util.MaterialFix;
+import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Textures;
 import gregtech.api.interfaces.ITexture;
@@ -109,6 +110,7 @@ public class Loaders {
     public static ItemStack XHE;
     public static ItemStack PA;
     public static ItemStack LES;
+    public static ItemStack CT;
     public static ItemStack[] LFC = new ItemStack[5];
 
     public static ItemStack[] NeutronAccelerators = new ItemStack[9];
@@ -139,6 +141,7 @@ public class Loaders {
         }
         Loaders.Generator_Diesel[0] = new DieselGenerator(1113, "basicgenerator.diesel.tier.04", "Turbo Supercharging Combustion Generator", 4).getStackForm(1L);
         Loaders.Generator_Diesel[1] = new DieselGenerator(1114, "basicgenerator.diesel.tier.05", "Ultimate Chemical Energy Releaser", 5).getStackForm(1L);
+        Loaders.CT = new CoolantTower(IDOffset + 24, "CoolantTower", "Coolant Tower").getStackForm(1L);
         CrackRecipeAdder.registerPipe(30995, MyMaterial.incoloy903, 15000, 8000, true);
         CrackRecipeAdder.registerWire(32749, MyMaterial.signalium, 12, 131072, 16, true);
         CrackRecipeAdder.registerWire(32737, MyMaterial.lumiium, 8, 524288, 64, true);
@@ -232,6 +235,7 @@ public class Loaders {
             Textures.BlockIcons.casingTexturePages[GoodGeneratorTexturePage][3] = TextureFactory.of(preciseUnitCasing, 0);
             Textures.BlockIcons.casingTexturePages[GoodGeneratorTexturePage][4] = TextureFactory.of(preciseUnitCasing, 1);
             Textures.BlockIcons.casingTexturePages[GoodGeneratorTexturePage][5] = TextureFactory.of(preciseUnitCasing, 2);
+            Textures.BlockIcons.casingTexturePages[GoodGeneratorTexturePage][6] = TextureFactory.of(GregTech_API.sBlockConcretes, 8);
         }
     }
 

--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -972,7 +972,7 @@ public class RecipeLoader_02 {
             MyMaterial.marCeM200.get(OrePrefixes.ingotHot, 19),
             null,
             5700,
-            1920,
+            122880,
             4500
         );
 
@@ -1465,6 +1465,18 @@ public class RecipeLoader_02 {
             120
         );
 
+        GT_Values.RA.addAssemblerRecipe(
+            new ItemStack[]{
+                GT_OreDictUnificator.get(OrePrefixes.pipeHuge, Materials.Plastic, 2),
+                GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Steel, 1),
+                GT_Utility.getIntegratedCircuit(1)
+            },
+            Materials.Concrete.getMolten(2304),
+            ItemRefer.Coolant_Tower.get(1),
+            200,
+            120
+        );
+
     }
 
     public static void InitLoadRecipe() {
@@ -1681,9 +1693,21 @@ public class RecipeLoader_02 {
             if (tPlasma == null) {
                 continue;
             }
-            tPlasma.amount = 100;
-            String tPlasmaName = FluidRegistry.getFluidName(tPlasma);
             int tUnit = plasmaFuel.mSpecialValue;
+            if (tUnit > 200_000) {
+                tPlasma.amount = 1500;
+            } else if (tUnit > 100_000) {
+                tPlasma.amount = 1000;
+            } else if (tUnit > 50_000) {
+                tPlasma.amount = 800;
+            } else if (tUnit > 10_000) {
+                tPlasma.amount = 500;
+            } else {
+                tPlasma.amount = 100;
+            }
+
+            String tPlasmaName = FluidRegistry.getFluidName(tPlasma);
+
             if (tPlasmaName.split("\\.", 2).length == 2) {
                 String tOutName = tPlasmaName.split("\\.", 2)[1];
                 FluidStack output = FluidRegistry.getFluidStack(tOutName, tPlasma.amount);
@@ -1693,9 +1717,9 @@ public class RecipeLoader_02 {
                     MyRecipeAdder.instance.addExtremeHeatExchangerRecipe(
                         tPlasma,
                         output,
-                        FluidRegistry.getFluidStack("ic2distilledwater", tUnit * 300 / 160),
-                        FluidRegistry.getFluidStack("ic2superheatedsteam", tUnit * 300),
-                        FluidRegistry.getFluidStack("supercriticalsteam", tUnit * 3),
+                        FluidRegistry.getFluidStack("ic2distilledwater", tUnit * 3 * tPlasma.amount / 160),
+                        FluidRegistry.getFluidStack("ic2superheatedsteam", tUnit * 3 * tPlasma.amount),
+                        FluidRegistry.getFluidStack("supercriticalsteam", tUnit * 3 * tPlasma.amount / 100),
                         1
                     );
                 }

--- a/src/main/java/goodgenerator/util/ItemRefer.java
+++ b/src/main/java/goodgenerator/util/ItemRefer.java
@@ -146,6 +146,7 @@ public final class ItemRefer {
     public static ItemRefer Compact_Fusion_MK4 = getItemStack(LFC[3]);
     public static ItemRefer Compact_Fusion_MK5 = getItemStack(LFC[4]);
     public static ItemRefer Large_Essentia_Smeltery = getItemStack(LES);
+    public static ItemRefer Coolant_Tower = getItemStack(CT);
 
     private Item mItem = null;
     private Block mBlock = null;

--- a/src/main/resources/assets/goodgenerator/lang/en_US.lang
+++ b/src/main/resources/assets/goodgenerator/lang/en_US.lang
@@ -278,9 +278,8 @@ value.neutron_activator.0=Minimum Neutron Kinetic Energy:
 value.neutron_activator.1=Maximum Neutron Kinetic Energy:
 value.neutron_activator.2= MeV
 value.extreme_heat_exchanger.0=Max Hot Fluid Input:
-value.extreme_heat_exchanger.1=Max Distilled Water Input:
-value.extreme_heat_exchanger.2=Max Heated Fluid Output:
-value.extreme_heat_exchanger.3=Max Overheated Fluid Output:
+value.extreme_heat_exchanger.1=Max Distilled Water Input(Normal):
+value.extreme_heat_exchanger.2=Max Distilled Water Input(OverHeated):
 value.extreme_heat_exchanger.4=Threshold:
 value.precise_assembler.0=Need MK-
 value.precise_assembler.1= Casing
@@ -399,6 +398,9 @@ LargeEssentiaSmeltery.hint.4=0 - Air
 LargeEssentiaSmeltery.hint.5=1 - Basic Hatch/Magic Casing
 LargeEssentiaSmeltery.hint.6=2 - Muffler Hatch
 LargeEssentiaSmeltery.hint.7=Support TecTech Hatches.
+CoolantTower.hint.0=Any kind of GT concrete
+CoolantTower.hint.1=28x Tungstencarbide Frame Boxes
+CoolantTower.hint.2=1 - Input/Output Hatch
 
 #Chat
 largeessentiagenerator.chat= Installed!


### PR DESCRIPTION
another way to turn plasma into power.
![2022-07-02_15 17 20](https://user-images.githubusercontent.com/60341015/176991069-581bb4d1-d529-40b7-9978-9032c06f7d86.png)

the fusion generates plasma, then heat distilled water into supercritial steam (3x base power value than plasma) in EHE(extrem heat exchanger).
the plasma has higher fuel value can be processed more quickly
|fuel value (eu/mb)|speed (mb/s)|
|----|----|
|>200000|1500|
|200000~100000|1000|
|50000~10000|500|
|<10000|100|

it means the low power plasma like helium will become very slow in EHE.

the SC steam turbine can generate power from supercritial steam(1mb = 100eu). its optimal flow is the same as the normal steam optimal flow. it means it actually has higher output than regular plasma turbine with the same turbine.
![image](https://user-images.githubusercontent.com/60341015/176991576-fd827c15-3d84-4ba2-af22-8ecfb2af9db8.png)
2400L/t * 100 = 240000EU/t about 1.7x plasma power.
the price is the supercritial steam cause 10x damage to the turbine.

the SC steam turbine will output normal steam 1:1 after processing the supercritial steam, the coolant tower is used to turn the steam back to distilled water instantly, otherwise you have use regular steam turbine to process these low energy steam.

the setup in illustration is using zinc plasma in mk2 and turbine material is neutronium.
the EHE is outputting about 7040mb/t supercritial steam, which can feed about 3 SC turbine with neutronium turbine, each turbine is outputing 324000eu/t (zpm@2.47a).

the SC steam turbine and EHE is gated in luv. the coolant tower is gated in hv.

