### PR TITLE
Use the same check as in multiblock base to check the structure

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -222,7 +222,10 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
                 mUpdate = 50;
                 mUpdated = false;
             }
-            if (--mUpdate == 0 || --mStartUpCheck == 0 || cyclicUpdate_EM() || aBaseMetaTileEntity.hasWorkJustBeenEnabled()) {
+            if (--mUpdate == 0
+                    || --mStartUpCheck == 0
+                    || cyclicUpdate_EM()
+                    || aBaseMetaTileEntity.hasWorkJustBeenEnabled()) {
                 checkStructure(true, aBaseMetaTileEntity);
             }
             if (mStartUpCheck < 0) {

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -218,7 +218,11 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
                 this.mEUStore = (int) aBaseMetaTileEntity.getStoredEU();
                 checkRecipe(mInventory[1]);
             }
-            if (--mUpdate == 0 || --mStartUpCheck == 0) {
+            if (mUpdated) {
+                mUpdate = 50;
+                mUpdated = false;
+            }
+            if (--mUpdate == 0 || --mStartUpCheck == 0 || cyclicUpdate_EM() || aBaseMetaTileEntity.hasWorkJustBeenEnabled()) {
                 checkStructure(true, aBaseMetaTileEntity);
             }
             if (mStartUpCheck < 0) {


### PR DESCRIPTION
Fusion reactors fail to check their structure correctly. This results in the need to always place the controller last. I implemented the same check as in the multiblock base to check the structure from time to time, or immedietly if you restart it.