### PR TITLE
Allow multiple hatches in Large Essentia Generator

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
@@ -175,13 +175,13 @@ public class LargeEssentiaGenerator extends GT_MetaTileEntity_TooltipMultiBlockB
                         },
                         {
                             "T  TXT  T",
-                            "  TCCCT  ",
-                            " TCCCCCT ",
-                            "TCCCCCCCT",
-                            "XCCCCCCCX",
-                            "TCCCCCCCT",
-                            " TCCCCCT ",
-                            "  TCCCT  ",
+                            "  TCXCT  ",
+                            " TCCXCCT ",
+                            "TCCCXCCCT",
+                            "XXXXXXXXX",
+                            "TCCCXCCCT",
+                            " TCCXCCT ",
+                            "  TCXCT  ",
                             "T  TXT  T"
                         }
                     }))


### PR DESCRIPTION
LEG allows you to use only 1 essentia input hatch, because other places for hatches will be used for dynamo hatch, maintenance hatch and input hatch for liquid. So you cannot use multiple essentia type in 1 generator and multiple liquid type, but LGE allows you to do that by its own. Moreover, it cannot use more than 2 essentia per tick because of slow essentia providers (export busses doesn't work).