### PR TITLE
Fix Dalisenite not having freezer recipe

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ dependencies {
 
 	compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.44:dev')
 	compile('com.github.GTNewHorizons:StructureLib:1.1.7:dev')
-	compile('com.github.GTNewHorizons:bartworks:0.5.75:dev')
+	compile('com.github.GTNewHorizons:bartworks:0.5.94:dev')
 	compile('com.github.GTNewHorizons:NotEnoughItems:2.2.28-GTNH:dev')
 	compile('com.github.GTNewHorizons:TecTech:5.0.37:dev')
 

--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -88,6 +88,12 @@ public class RecipeLoader_02 {
         CrackRecipeAdder.reAddBlastRecipe(MyMaterial.hikarium, 1200, 30720, 5400, true);
         CrackRecipeAdder.reAddBlastRecipe(MyMaterial.tairitsu, 1200, 1966080, 7400, true);
 
+        GT_Values.RA.addVacuumFreezerRecipe(
+                MyMaterial.dalisenite.get(OrePrefixes.ingotHot, 1),
+                MyMaterial.dalisenite.get(OrePrefixes.ingot, 1),
+                315,
+                120);
+
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     MyMaterial.zircaloy4.get(OrePrefixes.plate, 4),


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11636
Other materials don't have such issue because they don't have autogenenerated gas EBF recipes. Dalisenite itself doesn't have `ANAEROBE_SMELTING` nor `NOBLE_GAS_SMELTING` tags, but `LuVTierMaterial`, which Dalisenite has as component, has `NOBLE_GAS_SMELTING` tag. So `DustLoader` generates gas EBF recipe, causing duplicated recipes. (https://github.com/GTNewHorizons/GoodGenerator/pull/88)
Modifying `Werkstoff#contains` will break many stuff, so I simply added back freezer recipe.