### PR TITLE
Add better naq fuel recipes to combat fusion spam

### DIFF
--- a/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
@@ -10,6 +10,7 @@ import goodgenerator.util.MyRecipeAdder;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_OreDictUnificator;
+import gtPlusPlus.core.material.ELEMENT;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
@@ -89,6 +90,23 @@ public class FuelRecipeLoader {
                 160,
                 2);
 
+        // Alternate higher tier recipe
+        MyRecipeAdder.instance.addNaquadahFuelRefineRecipe(
+                new FluidStack[] {
+                    MyMaterial.naquadahBasedFuelMkIII.getFluidOrGas(2000),
+                    new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 1440)
+                },
+                new ItemStack[] {
+                    MyMaterial.extremelyUnstableNaquadah.get(OrePrefixes.dust, 27),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Bedrockium, 64),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 64),
+                    MyMaterial.orundum.get(OrePrefixes.dust, 64),
+                },
+                MyMaterial.naquadahBasedFuelMkIV.getFluidOrGas(500),
+                75000000,
+                160,
+                2);
+
         MyRecipeAdder.instance.addNaquadahFuelRefineRecipe(
                 new FluidStack[] {
                     MyMaterial.naquadahBasedFuelMkIV.getFluidOrGas(2000),
@@ -102,5 +120,21 @@ public class FuelRecipeLoader {
                 100000000,
                 200,
                 2);
+
+        // Alternate higher tier recipe
+        MyRecipeAdder.instance.addNaquadahFuelRefineRecipe(
+                new FluidStack[] {
+                    MyMaterial.naquadahBasedFuelMkIV.getFluidOrGas(2000),
+                    FluidRegistry.getFluidStack("heavyradox", 1000),
+                },
+                new ItemStack[] {
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SpaceTime, 8),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.TranscendentMetal, 16),
+                    MyMaterial.atomicSeparationCatalyst.get(OrePrefixes.dust, 48),
+                },
+                MyMaterial.naquadahBasedFuelMkV.getFluidOrGas(750),
+                300000000,
+                200,
+                3);
     }
 }

--- a/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
@@ -94,7 +94,7 @@ public class FuelRecipeLoader {
         MyRecipeAdder.instance.addNaquadahFuelRefineRecipe(
                 new FluidStack[] {
                     MyMaterial.naquadahBasedFuelMkIII.getFluidOrGas(2000),
-                    new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 1440)
+                    new FluidStack(FluidRegistry.getFluid("molten.hypogen"), 1440)
                 },
                 new ItemStack[] {
                     MyMaterial.extremelyUnstableNaquadah.get(OrePrefixes.dust, 27),

--- a/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/FuelRecipeLoader.java
@@ -10,7 +10,6 @@ import goodgenerator.util.MyRecipeAdder;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_OreDictUnificator;
-import gtPlusPlus.core.material.ELEMENT;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;


### PR DESCRIPTION
Added new recipes for naq fuel 4 and 5 that have better conversion ratios between them and use higher tier materials. These additions aim to reduce the sheer amount of low tier items needed to make naq fuel and use less, but higher tier materials instead. 
There also are new recipes for the high density ingots that also follow this rule (they are in the following pr):
https://github.com/GTNewHorizons/bartworks/pull/218

Here is the google doc I used for my calculations. The first page contains the current recipes and the second page has the new ones.
https://docs.google.com/spreadsheets/d/1NtElMYIg9QAs6LcnT-XHwODBIteLxiE5jDWRcKQWpyc/edit?usp=sharing

These are the new recipes condensed into one image:
![image](https://user-images.githubusercontent.com/93287602/195928246-cf2f2d2e-1ea2-4939-86f4-40043a7a347b.png)

Please comment if you have any feedback or dm me on discord