### PR TITLE
Naq Fuel 1,2,3 Changes

### DIFF
--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -575,17 +575,16 @@ public class RecipeLoader {
         GT_Values.RA.addMultiblockChemicalRecipe(
                 new ItemStack[] {
                     GT_Utility.getIntegratedCircuit(1),
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Praseodymium, 16),
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Samarium, 24),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 4),
                     GT_OreDictUnificator.get(OrePrefixes.dust, Materials.ElectrumFlux, 32),
                 },
                 new FluidStack[] {
-                    MyMaterial.naquadahBasedFuelMkI.getFluidOrGas(1000), MyMaterial.naquadahGas.getFluidOrGas(2500)
+                    MyMaterial.naquadahBasedFuelMkI.getFluidOrGas(100), MyMaterial.naquadahGas.getFluidOrGas(1500)
                 },
-                new FluidStack[] {MyMaterial.naquadahBasedFuelMkII.getFluidOrGas(1000)},
+                new FluidStack[] {MyMaterial.naquadahBasedFuelMkII.getFluidOrGas(100)},
                 null,
-                200,
-                480000);
+                500,
+                525000);
 
         GT_Values.RA.addBlastRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Naquadria, 32),

--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -1570,10 +1570,10 @@ public class RecipeLoader {
                 2040);
 
         GT_Values.RA.addCentrifugeRecipe(
-                MyMaterial.radioactiveSludge.get(OrePrefixes.dust, 9),
+                MyMaterial.radioactiveSludge.get(OrePrefixes.dust, 4),
                 null,
                 null,
-                Materials.Radon.getGas(45),
+                Materials.Radon.getGas(20),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 2),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 1),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1),

--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -33,17 +33,6 @@ public class RecipeLoader {
 
         GT_Values.RA.addAssemblerRecipe(
             new ItemStack[] {
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Hafnium, 8L),
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.NaquadahAlloy, 8L),
-                GT_Utility.getIntegratedCircuit(1)
-            },
-            Materials.Lead.getMolten(1152),
-            ItemRefer.Radiation_Protection_Plate.get(1),
-            400,
-            1920);
-
-        GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] {
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Lanthanum, 4L),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.NaquadahAlloy, 8L),
                 GT_Utility.getIntegratedCircuit(1)

--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -32,16 +32,15 @@ public class RecipeLoader {
                 1920);
 
         GT_Values.RA.addAssemblerRecipe(
-            new ItemStack[] {
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Lanthanum, 4L),
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.NaquadahAlloy, 8L),
-                GT_Utility.getIntegratedCircuit(1)
-            },
-            Materials.Lead.getMolten(1152),
-            ItemRefer.Radiation_Protection_Plate.get(1),
-            400,
-            1920);
-
+                new ItemStack[] {
+                    GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Lanthanum, 4L),
+                    GT_OreDictUnificator.get(OrePrefixes.plate, Materials.NaquadahAlloy, 8L),
+                    GT_Utility.getIntegratedCircuit(1)
+                },
+                Materials.Lead.getMolten(1152),
+                ItemRefer.Radiation_Protection_Plate.get(1),
+                400,
+                1920);
 
         Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null
                 ? FluidRegistry.getFluid("molten.indalloy140")

--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -521,9 +521,9 @@ public class RecipeLoader {
                 2040);
 
         GT_Values.RA.addBlastRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 32),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 16),
                 GT_Utility.getIntegratedCircuit(16),
-                MyMaterial.fluoroantimonicAcid.getFluidOrGas(1000),
+                Materials.HydrofluoricAcid.getFluid(3000),
                 MyMaterial.acidNaquadahEmulsion.getFluidOrGas(2000),
                 MyMaterial.radioactiveSludge.get(OrePrefixes.dust, 3),
                 null,
@@ -534,7 +534,7 @@ public class RecipeLoader {
         GT_Values.RA.addMultiblockChemicalRecipe(
                 new ItemStack[] {
                     GT_Utility.getIntegratedCircuit(3),
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Quicklime, 32)
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Quicklime, 8)
                 },
                 new FluidStack[] {
                     MyMaterial.acidNaquadahEmulsion.getFluidOrGas(1000),
@@ -1549,18 +1549,18 @@ public class RecipeLoader {
                 2040);
 
         GT_Values.RA.addCentrifugeRecipe(
-                MyMaterial.radioactiveSludge.get(OrePrefixes.dust, 1),
+                MyMaterial.radioactiveSludge.get(OrePrefixes.dust, 9),
                 null,
                 null,
-                Materials.Radon.getGas(5),
-                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Calcium, 2),
-                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Calcium, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Naquadah, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Uranium, 1),
-                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Plutonium, 1),
-                WerkstoffLoader.Tiberium.get(OrePrefixes.dustSmall, 1),
+                Materials.Radon.getGas(45),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 2),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 1),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Uranium, 1),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Plutonium, 1),
+                WerkstoffLoader.Tiberium.get(OrePrefixes.dust, 1),
                 new int[] {10000, 9500, 8000, 2500, 2000, 2000},
-                100,
+                900,
                 120);
     }
 

--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -22,15 +22,37 @@ public class RecipeLoader {
         // Radiation Protection Plate
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                    GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Lanthanum, 8L),
+                    GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Iridium, 8L),
                     GT_OreDictUnificator.get(OrePrefixes.plate, Materials.NaquadahAlloy, 8L),
-                    GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Neutronium, 1L),
                     GT_Utility.getIntegratedCircuit(1)
                 },
                 Materials.Lead.getMolten(1152),
                 ItemRefer.Radiation_Protection_Plate.get(1),
                 400,
                 1920);
+
+        GT_Values.RA.addAssemblerRecipe(
+            new ItemStack[] {
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Hafnium, 8L),
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.NaquadahAlloy, 8L),
+                GT_Utility.getIntegratedCircuit(1)
+            },
+            Materials.Lead.getMolten(1152),
+            ItemRefer.Radiation_Protection_Plate.get(1),
+            400,
+            1920);
+
+        GT_Values.RA.addAssemblerRecipe(
+            new ItemStack[] {
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Lanthanum, 4L),
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.NaquadahAlloy, 8L),
+                GT_Utility.getIntegratedCircuit(1)
+            },
+            Materials.Lead.getMolten(1152),
+            ItemRefer.Radiation_Protection_Plate.get(1),
+            400,
+            1920);
+
 
         Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null
                 ? FluidRegistry.getFluid("molten.indalloy140")

--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -565,12 +565,12 @@ public class RecipeLoader {
         GT_Values.RA.addFuel(MyMaterial.naquadahGas.get(OrePrefixes.cell), null, 1024, 1);
 
         GT_Values.RA.addFusionReactorRecipe(
-                MyMaterial.lightNaquadahFuel.getFluidOrGas(65),
-                MyMaterial.heavyNaquadahFuel.getFluidOrGas(30),
+                MyMaterial.lightNaquadahFuel.getFluidOrGas(780),
+                MyMaterial.heavyNaquadahFuel.getFluidOrGas(360),
                 MyMaterial.naquadahBasedFuelMkI.getFluidOrGas(100),
-                5,
+                500,
                 26000,
-                330000000);
+                320000000);
 
         GT_Values.RA.addMultiblockChemicalRecipe(
                 new ItemStack[] {

--- a/src/main/java/goodgenerator/main/GG_Config_Loader.java
+++ b/src/main/java/goodgenerator/main/GG_Config_Loader.java
@@ -11,8 +11,8 @@ public class GG_Config_Loader {
 
     public static int LiquidAirConsumptionPerSecond = 2400;
     public static int[] NaquadahFuelVoltage = new int[] {
-        12960, 2200, 32400, 220000,
-        380000, 9511000, 88540000, 399576000
+        12960, 2200, 32400, 975000,
+        2300000, 9511000, 88540000, 399576000
     };
     public static int[] NaquadahFuelTime = new int[] {100, 500, 150, 20, 20, 80, 100, 160};
     public static int[] CoolantEfficiency = new int[] {275, 150, 105};


### PR DESCRIPTION
Redo of https://github.com/GTNewHorizons/GoodGenerator/pull/62 because I messed up the original branch and now its gone. 

# Naq Fuel Mk1,2,3 Rework/Buff
### Overall Goals
- Add a competitive alternative to helium plasma available early enough and strong enough to create real power diversity but not too much to make helium plasma really bad in comparison
- Make the previously useless/outclassed Mk1/2/3 Naq Fuels viable
- Make Naq Fuel progression earlier and more sensible

### Naquadah Emulsion Line
#### Changes:
Enriched Naquadah recipe for Acid Naquadah Emulsion:
- Fluid input changed: 1000L Fluoroantimonic Acid -> 3000L Hydrofluoric Acid
- Enriched Naq input reduced: 32 -> 16

Naquadah Emulsion recipe:
- Quicklime input reduced: 32 -> 8
- Small pile of Antimony Trioxide removed
(Affects the naquadria path for Acid Naquadah Emulsion but I doubt anyone using naq fuel is gonna be seriously affected by this)

Misc:
- Radioactive Sludge Dust centrifuge recipe adjusted to use full dusts (TODO)

#### Reasoning:
This line has quite a bit of stuff but currently the Naquadria recipe is the only one being used since it's required for Mk4 and that's the only naq fuel worth using. For Mk1/2, they will be early enough that Naquadria may still be a problem, which leaves the Enriched Naq recipe. The recipe looks pretty costly for little return, so I chose to reduce its input costs and I will go from there based on the results.


### Mk1 Naq Fuel - very late ZPM
#### Changes:
Recipe reworked:
- Moved down to Mk2 Fusion: Starting cost 330meu -> 320meu
- Instead of a 0.25s recipe, it will be a 25s recipe
- Inputs changed:
- Light Naq Fuel: 65L -> 780L
- Heavy Naq Fuel: 30L -> 360L
- Output amount unchanged

Fuel value increased: 220,000eu/t base -> 975,000eu/t base

#### Notes:
A single Mk2 fusion will be able to maintain a Molten Naq boosted reactor exactly.
A Molten Naq + Cryotheum boosted reactor will produce ~5x as much power as a Helium Plasma mk2 (Mk2 on Helium Plasma w/ Large Draconium Turbines makes ~1,920,000eu/t).

#### Reasoning:
Mk1 is currently used as just a stepping stone to the equally useless Mk2. Downtiering it to late ZPM allows it to see some use before being outclassed by later fuels. The goal is to make Mk1 fuel a more appealing option than spamming fusion for plasma. The massive difference in power between it and Helium Plasma is to account for the additional resource requirements since it is competing with a fuel that is made of two super easy to get fluids.

The recipe time change is to account for it being a fusion recipe. Since fusion requires constant uptime to not burn startup energy,  needing input every 0.25s is very punishing and right now it produces way more than a single Naq reactor can keep up with. This change should make constant uptime much more reasonable and also make it not unnecessarily overproduce fuel.

Here is some very rough math for these Mk1 numbers on a Molten Naq + Cryotheum reactor:
![image](https://user-images.githubusercontent.com/43712386/182449331-db001396-df04-4ff7-9257-14f3be8d6357.png)


### Mk2 Naq Fuel - mid UV
#### Changes:
Recipe reworked:
- EU/t and voltage changed to require UHV hatches: 480,000eu/t (UV) -> 525,000eu/t (UHV)
- Removed Praseodymium and Samarium dusts from inputs
- Added new input: 4x Nether Star Dust
- Reduced input/output fluid amounts:
- Naquadah Gas: 2500L -> 1500L
- Naq Fuel Mk1: 1000L -> 100L
- Naq Fuel Mk2: 1000L -> 100L
- Recipe time increased: 10s -> 25s

Fuel value increased: 380,000eu/t base -> 2,300,000eu/t base

#### Notes:
Keeping a Mk2 LCR at 100% uptime will produce exactly enough for 1 Molten Naq boosted reactor.
Net output should be ~5x higher than Helium Plasma from Mk3 Fusion with Large Cosmic when running a Molten Naq + Cryotheum boosted reactor. 

#### Reasoning:
Technically, Mk2 is available immediately after Mk1 in ZPM if you use laser hatches on an MCR, however there is a new soft gate in the nether star input. Nether stars become trivial once you hit the T7 rocket and unlock the ore, but the recipe is still doable with a good salis setup before that.

The current recipe seems extremely expensive and hard to maintain at the stage where Mk2 is available, especially the Samarium. The Praseodymium isn't as bad because a good amount of people do the Thorium fuel line for Lutetium around this tier, and Praseodymium is a byproduct of that. I chose to remove these two dusts is because they are both mostly gated behind long, currently optional lines. Requiring two unrelated lines for a fuel source, especially when one of the outputs of these lines is very important elsewhere, is very discouraging and may push people away from Mk2 fuel. Basically, why bother setting up multiple huge processing lines when you can just pump/siphon two easy fluids and spam fusion reactors.

I kept Fluxed Electrum in the recipe because it was the easiest one to setup but still not super easy to deal with because you need to source a lot of different metals to keep it running.

Thought process for the fuel value is similar to Mk1 where the goal is to make a very strong alternative to helium plasma and to turn Mk2 into a viable fuel. Here is the math for a Cryotheum + Molten Naq reactor:
![image](https://user-images.githubusercontent.com/43712386/182748541-0e0da29c-8065-49d2-9dbd-5ac4983ab7b5.png)

### Mk3 Naq Fuel - mid UHV
(unsure if this already happened)
#### Change:
- Field Restriction Coil recipe cost reduced: 1 Nano Circuit -> 1 Bio Mainframe

#### Reasoning:
Currently, Mk3 is unlocked at the same time as Mk4 at around UEV, which means it is outclassed the moment you get access to it. This moves Mk3 down a tier so that it has a small chance to shine before being upgradeable into Mk4.

I do not believe Mk3 needs any other changes.

### Misc. Changes
New Radiation Proof Plate recipes:
- 8x Dense Iridium Plate + 8x Naq Alloy Plate + 1152L Molten Lead -> 1x Radiation Proof Plate
- 8x Hafnium Plate + 8x Naq Alloy Plate + 1152L Molten Lead -> 1x Radiation Proof Plate***
***not added for now

Existing Radiation Proof Plate recipe changed:
- Old: 8x Dense Lanthanum Plate + 8x Naq Alloy Plate + 1152L Molten Lead -> 1x Radiation Proof Plate
- New: 4x Lanthanum Plate + 8x Naq Alloy Plate + 1152L Molten Lead -> 1x Radiation Proof Plate
#### Reasoning:
With the existing recipe for these plates, a single Large Naq Reactor requires 21,888 Lanthanum ingots. This is unreasonably expensive pre-T8 rocket and a complete joke afterwards. I want to keep Lanthanum in the recipe because the Monazite/Bastline products are very underused, so I instead reduced the amount used significantly. Now, it only takes 1216 Lanthanum ingots if you go that route, which doesn't affect post-T8 costs because it was already ridiculously cheap at that point. This is doable if you have a Bastline running, and also doable via GT++ rare earth processing or Toxic Everglades. A Hafnium recipe was added as an incentive to at least start one of those lines, and the Iridium recipe exists for anyone against doing these lines. The amounts used are to try and incentivize the Monazite/Bastline without requiring it for Naq Fuel. Neutronium foils were removed because the smelting times are a large turn off at the tier where Mk1 unlocks.

