### PR TITLE
Depleted Th Fuel centrifuge: Increase first stack of praseodymium chance from 10% to 100%

### DIFF
--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -1494,7 +1494,7 @@ public class RecipeLoader {
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Praseodymium, 32),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Boron, 2),
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 4),
-                new int[] {10000, 8000, 1000, 8000, 3000, 5000},
+                new int[] {10000, 8000, 10000, 8000, 3000, 5000},
                 1500,
                 1040);
 


### PR DESCRIPTION
Currently, the post-rework depleted thorium fuel, when centrifuged, returns the first stack of 64 praseodymium dust at a 10% chance. I suspect this was just a typo, and I've bumped it up to 100% again. This should make it so it's no longer a drastic reduction in praseodymium yield when the update happens.