### PR TITLE
clean the long power use base and add item util for tiered material

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,8 +23,8 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:EnderIO:2.3.1.43:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.19:dev') {transitive = false}
 
-	  compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.27:dev') {transitive = false}
-	  compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.3.19-GTNH:dev') {transitive =  false}
+    compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.27:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.3.19-GTNH:dev') {transitive =  false}
     compileOnly("com.github.GTNewHorizons:ProjectRed:4.7.7-GTNH:dev") {transitive = false}
 
 	runtime('com.github.GTNewHorizons:NewHorizonsCoreMod:1.9.106:dev')

--- a/src/main/java/goodgenerator/blocks/tileEntity/PreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/PreciseAssembler.java
@@ -203,7 +203,7 @@ public class PreciseAssembler extends GT_MetaTileEntity_LongPowerUsageBase<Preci
                                 this.getBaseMetaTileEntity(),
                                 this.lastRecipe,
                                 false,
-                                Math.min(getMachineVoltageLimit(), getMaxInputEnergyPA()),
+                                Math.min(getMachineVoltageLimit(), getRealVoltage()),
                                 inputFluids,
                                 getStoredItemFromHatch(bus));
                 if (this.lastRecipe != null && this.lastRecipe.mSpecialValue <= (casingTier + 1)) {
@@ -211,8 +211,7 @@ public class PreciseAssembler extends GT_MetaTileEntity_LongPowerUsageBase<Preci
                     this.mEfficiencyIncrease = 10000;
                     this.lastRecipe.isRecipeInputEqual(true, inputFluids, getStoredItemFromHatch(bus));
                     mOutputItems = this.lastRecipe.mOutputs;
-                    calculateOverclockedNessMulti(
-                            this.lastRecipe.mEUt, this.lastRecipe.mDuration, 1, getMaxInputEnergyPA());
+                    calculateOverclockedNessMulti(this.lastRecipe.mEUt, this.lastRecipe.mDuration, 1, getRealVoltage());
                     this.updateSlots();
                     if (this.lEUt > 0) {
                         this.lEUt = (-this.lEUt);
@@ -228,13 +227,13 @@ public class PreciseAssembler extends GT_MetaTileEntity_LongPowerUsageBase<Preci
                                 this.getBaseMetaTileEntity(),
                                 this.lastRecipe,
                                 false,
-                                Math.min(getMachineVoltageLimit(), getMaxInputEnergyPA()),
+                                Math.min(getMachineVoltageLimit(), getRealVoltage()),
                                 inputFluids,
                                 getStoredItemFromHatch(bus));
                 if (this.lastRecipe != null) {
                     this.mEfficiency = (10000 - (this.getIdealStatus() - this.getRepairStatus()) * 1000);
                     this.mEfficiencyIncrease = 10000;
-                    long fullInput = getMaxInputEnergyPA();
+                    long fullInput = getRealVoltage();
                     int pall = handleParallelRecipe(this.lastRecipe, inputFluids, getStoredItemFromHatch(bus), (int)
                             Math.min((long) Math.pow(2, 4 + (casingTier + 1)), fullInput / this.lastRecipe.mEUt));
                     if (pall <= 0) continue;
@@ -244,7 +243,7 @@ public class PreciseAssembler extends GT_MetaTileEntity_LongPowerUsageBase<Preci
                             (long) this.lastRecipe.mEUt * (long) pall,
                             this.lastRecipe.mDuration / 2,
                             1,
-                            getMaxInputEnergyPA());
+                            getRealVoltage());
                     this.updateSlots();
                     if (this.lEUt > 0) {
                         this.lEUt = (-this.lEUt);
@@ -254,25 +253,6 @@ public class PreciseAssembler extends GT_MetaTileEntity_LongPowerUsageBase<Preci
             }
         }
         return false;
-    }
-
-    private long getMaxInputEnergyPA() {
-        long rEnergy = 0;
-        if (mEnergyHatches.size() == 1) {
-            // it works like most of the gt multies
-            return mEnergyHatches.get(0).getBaseMetaTileEntity().getInputVoltage();
-        }
-        for (GT_MetaTileEntity_Hatch_Energy tHatch : mEnergyHatches) {
-            if (isValidMetaTileEntity(tHatch)) {
-                rEnergy += tHatch.maxEUInput() * tHatch.maxAmperesIn();
-            }
-        }
-        for (GT_MetaTileEntity_Hatch tHatch : mExoticEnergyHatches) {
-            if (isValidMetaTileEntity(tHatch)) {
-                rEnergy += tHatch.maxEUInput() * ((GT_MetaTileEntity_Hatch_EnergyMulti) tHatch).Amperes;
-            }
-        }
-        return rEnergy;
     }
 
     @Override
@@ -299,11 +279,6 @@ public class PreciseAssembler extends GT_MetaTileEntity_LongPowerUsageBase<Preci
     public GT_Recipe.GT_Recipe_Map getRecipeMap() {
         if (this.mode == 0) return MyRecipeAdder.instance.PA;
         else return GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-    }
-
-    @Override
-    protected long getRealVoltage() {
-        return getMaxInputEnergyPA();
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/GT_MetaTileEntity_LongPowerUsageBase.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/GT_MetaTileEntity_LongPowerUsageBase.java
@@ -49,7 +49,24 @@ public abstract class GT_MetaTileEntity_LongPowerUsageBase<T extends GT_MetaTile
         return getInfoDataArray(this);
     }
 
-    protected abstract long getRealVoltage();
+    protected long getRealVoltage() {
+        long rEnergy = 0;
+        if (mEnergyHatches.size() == 1 && mExoticEnergyHatches.isEmpty()) {
+            // it works like most of the gt multies
+            return mEnergyHatches.get(0).getBaseMetaTileEntity().getInputVoltage();
+        }
+        for (GT_MetaTileEntity_Hatch_Energy tHatch : mEnergyHatches) {
+            if (isValidMetaTileEntity(tHatch)) {
+                rEnergy += tHatch.maxEUInput() * tHatch.maxAmperesIn();
+            }
+        }
+        for (GT_MetaTileEntity_Hatch tHatch : mExoticEnergyHatches) {
+            if (isValidMetaTileEntity(tHatch)) {
+                rEnergy += tHatch.maxEUInput() * ((GT_MetaTileEntity_Hatch_EnergyMulti) tHatch).Amperes;
+            }
+        }
+        return rEnergy;
+    }
 
     protected long getMaxInputAmps() {
         long rAmps = 0;

--- a/src/main/java/goodgenerator/items/MyMaterial.java
+++ b/src/main/java/goodgenerator/items/MyMaterial.java
@@ -1294,6 +1294,95 @@ public class MyMaterial implements Runnable {
             new Pair<>(Sulfur, 1),
             new Pair<>(Oxygen, 4));
 
+    public static final Werkstoff preciousMetalAlloy = new Werkstoff(
+            new short[] {0x9d, 0x90, 0xc6},
+            "Precious Metals Alloy",
+            new Werkstoff.Stats()
+                    .setBlastFurnace(true)
+                    .setMeltingPoint(10000)
+                    .setCentrifuge(true)
+                    .setSpeedOverride(100F),
+            Werkstoff.Types.MIXTURE,
+            new Werkstoff.GenerationFeatures()
+                    .onlyDust()
+                    .addMolten()
+                    .addMetalItems()
+                    .addCraftingMetalWorkingItems()
+                    .addMixerRecipes((short) 6),
+            OffsetID + 108,
+            TextureSet.SET_SHINY,
+            new Pair<>(WerkstoffLoader.Ruthenium, 1),
+            new Pair<>(WerkstoffLoader.Rhodium, 1),
+            new Pair<>(Palladium, 1),
+            new Pair<>(Platinum, 1),
+            new Pair<>(Osmium, 1),
+            new Pair<>(Iridium, 1));
+
+    public static final Werkstoff enrichedNaquadahAlloy = new Werkstoff(
+            new short[] {0x16, 0x07, 0x40},
+            "Enriched Naquadah Alloy",
+            new Werkstoff.Stats()
+                    .setBlastFurnace(true)
+                    .setMeltingPoint(11000)
+                    .setCentrifuge(true)
+                    .setSpeedOverride(180F),
+            Werkstoff.Types.MIXTURE,
+            new Werkstoff.GenerationFeatures()
+                    .onlyDust()
+                    .addMolten()
+                    .addMetalItems()
+                    .addCraftingMetalWorkingItems()
+                    .addSimpleMetalWorkingItems()
+                    .addMultipleIngotMetalWorkingItems()
+                    .addMixerRecipes((short) 4),
+            OffsetID + 109,
+            TextureSet.SET_METALLIC,
+            new Pair<>(NaquadahEnriched, 8),
+            new Pair<>(Tritanium, 5),
+            new Pair<>(WerkstoffLoader.Californium, 3),
+            new Pair<>(BlackPlutonium, 2));
+
+    public static final Werkstoff metastableOganesson = new Werkstoff(
+            new short[] {0x14, 0x39, 0x7f},
+            "Metastable Oganesson",
+            "Og*",
+            new Werkstoff.Stats()
+                    .setBlastFurnace(true)
+                    .setProtons(118)
+                    .setMass(294)
+                    .setMeltingPoint(11000),
+            Werkstoff.Types.ELEMENT,
+            new Werkstoff.GenerationFeatures()
+                    .onlyDust()
+                    .addMolten()
+                    .addMetalItems()
+                    .addCraftingMetalWorkingItems(),
+            OffsetID + 110,
+            TextureSet.SET_SHINY);
+
+    public static final Werkstoff shirabon = new Werkstoff(
+            new short[] {0xe0, 0x15, 0x6d},
+            "Shirabon",
+            "Sh" + CharExchanger.shifter(9191),
+            new Werkstoff.Stats()
+                    .setBlastFurnace(true)
+                    .setProtons(500)
+                    .setMass(750)
+                    .setMeltingPoint(13000)
+                    .setSpeedOverride(640.0F)
+                    .setDurOverride(15728640)
+                    .setQualityOverride((byte) 26),
+            Werkstoff.Types.ELEMENT,
+            new Werkstoff.GenerationFeatures()
+                    .onlyDust()
+                    .addMolten()
+                    .addMetalItems()
+                    .addCraftingMetalWorkingItems()
+                    .addSimpleMetalWorkingItems()
+                    .addMultipleIngotMetalWorkingItems(),
+            OffsetID + 111,
+            TextureSet.SET_SHINY);
+
     @Override
     public void run() {}
 }

--- a/src/main/java/goodgenerator/loader/ComponentAssemblyLineMiscRecipes.java
+++ b/src/main/java/goodgenerator/loader/ComponentAssemblyLineMiscRecipes.java
@@ -7,6 +7,7 @@ import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import com.github.technus.tectech.recipe.TT_recipeAdder;
 import com.google.common.collect.HashBiMap;
 import cpw.mods.fml.common.registry.GameRegistry;
+import goodgenerator.util.StackUtils;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -211,7 +212,7 @@ public class ComponentAssemblyLineMiscRecipes {
                 new FluidStack[] {
                     new FluidStack(sold, 144 * t * 4),
                     CI.getTieredFluid(t, 144 * t * 2),
-                    CI.getAlternativeTieredFluid(t, 144 * t),
+                    StackUtils.getTieredFluid(t, 144 * t),
                     Materials.Lubricant.getFluid(1000 * (t - 2))
                 },
                 Compassline_Casing_LuV.get(1),
@@ -237,7 +238,7 @@ public class ComponentAssemblyLineMiscRecipes {
                 new FluidStack[] {
                     new FluidStack(sold, 144 * t * 4),
                     CI.getTieredFluid(t, 144 * t * 2),
-                    CI.getAlternativeTieredFluid(t, 144 * t),
+                    StackUtils.getTieredFluid(t, 144 * t),
                     Materials.Lubricant.getFluid(1000 * (t - 2))
                 },
                 Compassline_Casing_ZPM.get(1),
@@ -263,7 +264,7 @@ public class ComponentAssemblyLineMiscRecipes {
                 new FluidStack[] {
                     new FluidStack(sold, 144 * t * 4),
                     CI.getTieredFluid(t, 144 * t * 2),
-                    CI.getAlternativeTieredFluid(t, 144 * t),
+                    StackUtils.getTieredFluid(t, 144 * t),
                     Materials.Lubricant.getFluid(1000 * (t - 2))
                 },
                 Compassline_Casing_UV.get(1),
@@ -291,8 +292,8 @@ public class ComponentAssemblyLineMiscRecipes {
                 },
                 new FluidStack[] {
                     new FluidStack(sold, 144 * t * 4),
-                    Materials.Naquadria.getMolten(144 * t * 4),
                     CI.getTieredFluid(t, 144 * t * 2),
+                    StackUtils.getTieredFluid(t, 144 * t),
                     Materials.Lubricant.getFluid(1000 * (t - 2))
                 },
                 Compassline_Casing_UHV.get(1),
@@ -321,8 +322,8 @@ public class ComponentAssemblyLineMiscRecipes {
                 },
                 new FluidStack[] {
                     new FluidStack(sold, 144 * t * 4),
-                    Materials.Quantium.getMolten(144 * t * 4),
                     CI.getTieredFluid(t, 144 * t * 2),
+                    StackUtils.getTieredFluid(t, 144 * t),
                     Materials.Lubricant.getFluid(1000 * (t - 2))
                 },
                 Compassline_Casing_UEV.get(1),
@@ -351,7 +352,7 @@ public class ComponentAssemblyLineMiscRecipes {
                 new FluidStack[] {
                     new FluidStack(sold, 144 * t * 4),
                     CI.getTieredFluid(t, 144 * t * 2),
-                    CI.getAlternativeTieredFluid(t - 1, 144 * t * 2),
+                    StackUtils.getTieredFluid(t, 144 * t),
                     Materials.Lubricant.getFluid(1000 * (t - 2))
                 },
                 Compassline_Casing_UIV.get(1),
@@ -380,7 +381,7 @@ public class ComponentAssemblyLineMiscRecipes {
                 new FluidStack[] {
                     new FluidStack(sold, 144 * t * 4),
                     CI.getTieredFluid(t - 1, 144 * t * 2),
-                    CI.getAlternativeTieredFluid(t - 2, 144 * t * 2),
+                    StackUtils.getTieredFluid(t, 144 * t),
                     Materials.Lubricant.getFluid(1000 * (t - 2))
                 },
                 Compassline_Casing_UMV.get(1),
@@ -395,26 +396,35 @@ public class ComponentAssemblyLineMiscRecipes {
     private static void generateWrapRecipes() {
         for (int i = 0; i <= 10; i++) {
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] {getCircuit(i, 16)},
+                    new ItemStack[] {getCircuit(i, 16), GT_Utility.getIntegratedCircuit(16)},
                     Materials.SolderingAlloy.getMolten(72L),
                     new ItemStack(Loaders.circuitWrap, 1, i),
                     30 * 20,
                     30);
         }
         GT_Values.RA.addAssemblerRecipe(
-                new ItemStack[] {GameRegistry.findItemStack("dreamcraft", "item.NanoCircuit", 16)},
+                new ItemStack[] {
+                    GameRegistry.findItemStack("dreamcraft", "item.NanoCircuit", 16),
+                    GT_Utility.getIntegratedCircuit(16)
+                },
                 Materials.SolderingAlloy.getMolten(72L),
                 new ItemStack(Loaders.circuitWrap, 1, 11),
                 30 * 20,
                 30);
         GT_Values.RA.addAssemblerRecipe(
-                new ItemStack[] {GameRegistry.findItemStack("dreamcraft", "item.PikoCircuit", 16)},
+                new ItemStack[] {
+                    GameRegistry.findItemStack("dreamcraft", "item.PikoCircuit", 16),
+                    GT_Utility.getIntegratedCircuit(16)
+                },
                 Materials.SolderingAlloy.getMolten(72L),
                 new ItemStack(Loaders.circuitWrap, 1, 12),
                 30 * 20,
                 30);
         GT_Values.RA.addAssemblerRecipe(
-                new ItemStack[] {GameRegistry.findItemStack("dreamcraft", "item.QuantumCircuit", 16)},
+                new ItemStack[] {
+                    GameRegistry.findItemStack("dreamcraft", "item.QuantumCircuit", 16),
+                    GT_Utility.getIntegratedCircuit(16)
+                },
                 Materials.SolderingAlloy.getMolten(72L),
                 new ItemStack(Loaders.circuitWrap, 1, 13),
                 30 * 20,

--- a/src/main/java/goodgenerator/loader/RecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader.java
@@ -1577,5 +1577,7 @@ public class RecipeLoader {
     public static void Fixer() {
         MaterialFix.MaterialFluidExtractionFix(MyMaterial.atomicSeparationCatalyst);
         MaterialFix.MaterialFluidExtractionFix(MyMaterial.extremelyUnstableNaquadah);
+        MaterialFix.MaterialFluidExtractionFix(MyMaterial.metastableOganesson);
+        MaterialFix.MaterialFluidExtractionFix(MyMaterial.shirabon);
     }
 }

--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -22,6 +22,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+@SuppressWarnings("deprecation")
 public class RecipeLoader_02 {
 
     public static void RecipeLoad() {
@@ -87,12 +88,24 @@ public class RecipeLoader_02 {
         CrackRecipeAdder.reAddBlastRecipe(MyMaterial.dalisenite, 800, 491520, 8700, true);
         CrackRecipeAdder.reAddBlastRecipe(MyMaterial.hikarium, 1200, 30720, 5400, true);
         CrackRecipeAdder.reAddBlastRecipe(MyMaterial.tairitsu, 1200, 1966080, 7400, true);
+        CrackRecipeAdder.reAddBlastRecipe(MyMaterial.preciousMetalAlloy, 2400, 7864320, 10000, true);
+        CrackRecipeAdder.reAddBlastRecipe(MyMaterial.enrichedNaquadahAlloy, 2400, 7864320, 11000, true);
+        CrackRecipeAdder.reAddBlastRecipe(MyMaterial.metastableOganesson, 600, 7864320, 12000, true);
+        CrackRecipeAdder.reAddBlastRecipe(MyMaterial.shirabon, 600, 31457280, 13000, true);
+
+        GT_ModHandler.removeFurnaceSmelting(MyMaterial.dalisenite.get(OrePrefixes.dust)); // :doom:
 
         GT_Values.RA.addVacuumFreezerRecipe(
                 MyMaterial.dalisenite.get(OrePrefixes.ingotHot, 1),
                 MyMaterial.dalisenite.get(OrePrefixes.ingot, 1),
                 315,
                 120);
+
+        GT_Values.RA.addVacuumFreezerRecipe(
+                MyMaterial.shirabon.get(OrePrefixes.ingotHot, 1),
+                MyMaterial.shirabon.get(OrePrefixes.ingot, 1),
+                2400,
+                1966080);
 
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
@@ -1854,6 +1867,37 @@ public class RecipeLoader_02 {
                 MyMaterial.lumiium.get(OrePrefixes.dust, 1),
                 240,
                 120);
+
+        GT_Values.RA.addFusionReactorRecipe(
+                MyMaterial.enrichedNaquadahAlloy.getMolten(144),
+                WerkstoffLoader.Oganesson.getFluidOrGas(250),
+                MyMaterial.metastableOganesson.getMolten(36),
+                600,
+                491520,
+                1000000000);
+
+        MyRecipeAdder.instance.addNeutronActivatorRecipe(
+                null,
+                new ItemStack[] {MyMaterial.metastableOganesson.get(OrePrefixes.dust)},
+                new FluidStack[] {WerkstoffLoader.Oganesson.getFluidOrGas(250)},
+                null,
+                2000,
+                1100,
+                1000);
+
+        GT_Values.RA.addPlasmaForgeRecipe(
+                new ItemStack[] {ItemRefer.HiC_T5.get(0)},
+                new FluidStack[] {
+                    MyMaterial.metastableOganesson.getMolten(1152),
+                    MyMaterial.preciousMetalAlloy.getMolten(2304),
+                    Materials.SpaceTime.getMolten(288),
+                    Materials.DimensionallyTranscendentResidue.getFluid(5000)
+                },
+                new ItemStack[] {},
+                new FluidStack[] {MyMaterial.shirabon.getMolten(144)},
+                200,
+                1500000000,
+                13500);
     }
 
     public static void FinishLoadRecipe() {

--- a/src/main/java/goodgenerator/util/MaterialFix.java
+++ b/src/main/java/goodgenerator/util/MaterialFix.java
@@ -11,12 +11,18 @@ import gregtech.api.util.GT_Utility;
 
 public class MaterialFix {
     public static void MaterialFluidExtractionFix(Werkstoff material) {
-        if (material.hasItemType(OrePrefixes.ingot))
+        if (material.hasItemType(OrePrefixes.ingot)) {
             GT_Values.RA.addFluidExtractionRecipe(
                     material.get(OrePrefixes.ingot), null, material.getMolten(144), 0, 32, 8);
-        if (material.hasItemType(OrePrefixes.plate))
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Ingot.get(0), material.getMolten(144), material.get(OrePrefixes.ingot), 32, 48);
+        }
+        if (material.hasItemType(OrePrefixes.plate)) {
             GT_Values.RA.addFluidExtractionRecipe(
                     material.get(OrePrefixes.plate), null, material.getMolten(144), 0, 32, 8);
+            GT_Values.RA.addFluidSolidifierRecipe(
+                    ItemList.Shape_Mold_Plate.get(0), material.getMolten(144), material.get(OrePrefixes.plate), 32, 48);
+        }
         if (material.hasItemType(OrePrefixes.gearGtSmall))
             GT_Values.RA.addFluidExtractionRecipe(
                     material.get(OrePrefixes.gearGtSmall), null, material.getMolten(144), 0, 32, 8);

--- a/src/main/java/goodgenerator/util/StackUtils.java
+++ b/src/main/java/goodgenerator/util/StackUtils.java
@@ -1,11 +1,14 @@
 package goodgenerator.util;
 
+import goodgenerator.items.MyMaterial;
+import gregtech.api.enums.Materials;
 import gregtech.api.util.GT_Utility;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
 public class StackUtils {
 
@@ -77,5 +80,38 @@ public class StackUtils {
 
     public static HashMap<ItemStack, Integer> getTotalItems(ItemStack[] items) {
         return getTotalItems(Arrays.asList(items));
+    }
+
+    public static FluidStack getTieredFluid(int aTier, int aAmount) {
+        switch (aTier) {
+            case 0: // ULV
+                return Materials.RedAlloy.getMolten(aAmount);
+            case 1: // LV
+                return Materials.TinAlloy.getMolten(aAmount);
+            case 2: // MV
+                return Materials.RoseGold.getMolten(aAmount);
+            case 3: // HV
+                return MyMaterial.zircaloy4.getMolten(aAmount);
+            case 4: // EV
+                return MyMaterial.incoloy903.getMolten(aAmount);
+            case 5: // IV
+                return MyMaterial.titaniumBetaC.getMolten(aAmount);
+            case 6: // LuV
+                return MyMaterial.artheriumSn.getMolten(aAmount);
+            case 7: // ZPM
+                return MyMaterial.dalisenite.getMolten(aAmount);
+            case 8: // UV
+                return MyMaterial.tairitsu.getMolten(aAmount);
+            case 9: // UHV
+                return MyMaterial.preciousMetalAlloy.getMolten(aAmount);
+            case 10: // UEV
+                return MyMaterial.enrichedNaquadahAlloy.getMolten(aAmount);
+            case 11: // UIV
+                return MyMaterial.metastableOganesson.getMolten(aAmount);
+            case 12: // UMV
+                return Materials.SpaceTime.getMolten(aAmount);
+            default:
+                return MyMaterial.shirabon.getMolten(aAmount);
+        }
     }
 }


### PR DESCRIPTION
- move `ComponentAssemblyLine` to `GT_MetaTileEntity_LongPowerUsageBase` to avoid duplicating code
- add a fast way to get tier material in `StackUtils`
- add some new materials
- use both gg alloy and gt++ alloy for component assembly casing