### PR TITLE
Tweak QFT Recipe Inputs and Tiers

### DIFF
--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -46,10 +46,15 @@ public class NaquadahReworkRecipeLoader {
                 CORE.RA.addQuantumTransformerRecipe(
                         new ItemStack[] {
                             naquadahEarth.get(OrePrefixes.dust, 32),
-                            Materials.SodiumHydroxide.getDust(64),
+                            Materials.Sodium.getDust(64),
+                            Materials.Carbon.getDust(1),
                             GT_Utility.copyAmount(0, GenericChem.mSimpleNaquadahCatalyst)
                         },
-                        new FluidStack[] {fluoroantimonicAcid.getFluidOrGas(16000), P507.getFluidOrGas(10)},
+                        new FluidStack[] {
+                            Materials.Hydrogen.getGas(64000L),
+                            Materials.Fluorine.getGas(64000L),
+                            Materials.Oxygen.getGas(100L)
+                        },
                         new FluidStack[] {},
                         new ItemStack[] {
                             inertNaquadah.get(OrePrefixes.dust, 64),
@@ -58,17 +63,21 @@ public class NaquadahReworkRecipeLoader {
                             Materials.Gallium.getDust(64)
                         },
                         new int[] {2500, 2500, 2500, 2500},
-                        20 * 20,
-                        (int) GT_Values.VP[9],
+                        10 * 20,
+                        (int) GT_Values.VP[10],
                         2);
                 // Enriched Naquadah (UIV)
                 CORE.RA.addQuantumTransformerRecipe(
                         new ItemStack[] {
                             enrichedNaquadahEarth.get(OrePrefixes.dust, 32),
                             Materials.Zinc.getDust(64),
+                            Materials.Carbon.getDust(1),
                             GT_Utility.copyAmount(0, GenericChem.mAdvancedNaquadahCatalyst)
                         },
-                        new FluidStack[] {Materials.SulfuricAcid.getFluid(16000), P507.getFluidOrGas(10)},
+                        new FluidStack[] {
+                            Materials.SulfuricAcid.getFluid(16000),
+                            Materials.Oxygen.getGas(100L)
+                        },
                         new FluidStack[] {wasteLiquid.getFluidOrGas(32000)},
                         new ItemStack[] {
                             inertEnrichedNaquadah.get(OrePrefixes.dust, 64),
@@ -76,7 +85,7 @@ public class NaquadahReworkRecipeLoader {
                             ItemList.NaquadriaSupersolid.get(1)
                         },
                         new int[] {3300, 3300, 3300},
-                        20 * 20,
+                        10 * 20,
                         (int) GT_Values.VP[11],
                         3);
                 // Naquadria (UMV)
@@ -89,7 +98,7 @@ public class NaquadahReworkRecipeLoader {
                         new FluidStack[] {
                             Materials.PhosphoricAcid.getFluid(16000),
                             Materials.SulfuricAcid.getFluid(16000),
-                            P507.getFluidOrGas(10)
+                            Materials.Oxygen.getGas(100L)
                         },
                         new FluidStack[] {},
                         new ItemStack[] {
@@ -98,9 +107,9 @@ public class NaquadahReworkRecipeLoader {
                             Materials.Indium.getDust(64)
                         },
                         new int[] {3300, 3300, 3300},
-                        20 * 20,
+                        10 * 20,
                         (int) GT_Values.VP[12],
-                        4);
+                        3);
                 // Activate Them
                 MyRecipeAdder.instance.addNeutronActivatorRecipe(
                         new FluidStack[] {Materials.Nickel.getPlasma(2880)},

--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -74,10 +74,7 @@ public class NaquadahReworkRecipeLoader {
                             Materials.Carbon.getDust(1),
                             GT_Utility.copyAmount(0, GenericChem.mAdvancedNaquadahCatalyst)
                         },
-                        new FluidStack[] {
-                            Materials.SulfuricAcid.getFluid(16000),
-                            Materials.Oxygen.getGas(100L)
-                        },
+                        new FluidStack[] {Materials.SulfuricAcid.getFluid(16000), Materials.Oxygen.getGas(100L)},
                         new FluidStack[] {wasteLiquid.getFluidOrGas(32000)},
                         new ItemStack[] {
                             inertEnrichedNaquadah.get(OrePrefixes.dust, 64),

--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -84,7 +84,7 @@ public class NaquadahReworkRecipeLoader {
                         new int[] {3300, 3300, 3300},
                         10 * 20,
                         (int) GT_Values.VP[11],
-                        3);
+                        2);
                 // Naquadria (UMV)
                 CORE.RA.addQuantumTransformerRecipe(
                         new ItemStack[] {
@@ -104,7 +104,7 @@ public class NaquadahReworkRecipeLoader {
                             Materials.Indium.getDust(64)
                         },
                         new int[] {3300, 3300, 3300},
-                        10 * 20,
+                        5 * 20,
                         (int) GT_Values.VP[12],
                         3);
                 // Activate Them


### PR DESCRIPTION
- Simplified Fluoroantimonic Acid and P507 to their components, to minimize the amount of LCRs needed for these skips;
- Changed the last naqline skip to not be tier 4;
- Halved recipe times because these energy tiers are higher than the ones on the QFT's PR, which will also be changed in a similar way.

These naqline skips would still force a number of LCRs to stick around to create these intermediate fluids - the main thing that the QFT was designed to avoid - so I replaced them (Fluoroantimonic Acid and P507) with their elemental equivalents, which are Carbon, Fluorine, Antimony, Hydrogen and Oxygen. I left Phosphor out because P507 is used in tiny amounts, and the phosphor atom in a molecule of that is 1 in 54 atoms.

Additionally, I changed the last skip's tier to 3, instead of 4, because tier 4 is the one of chains built in UV+, which are used in UHV+. 