### PR TITLE
make sc turbine damage 2x faster than normal turbine

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/SupercriticalFluidTurbine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/SupercriticalFluidTurbine.java
@@ -7,6 +7,7 @@ import gregtech.api.interfaces.IIconContainer;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+import gregtech.api.objects.XSTR;
 import gregtech.api.render.TextureFactory;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
@@ -100,7 +101,8 @@ public class SupercriticalFluidTurbine extends GT_MetaTileEntity_LargeTurbineBas
 
     @Override
     public int getDamageToComponent(ItemStack aStack) {
-        return looseFit ? 2 : 8;
+        // 2x more damage than normal turbine
+        return looseFit ? (XSTR.XSTR_INSTANCE.nextInt(2) == 0 ? 0 : 1) : 2;
     }
 
     @Override


### PR DESCRIPTION
the origin value is 8x faster than normal turbine. it means a large tungstensteel turbine will break in 2-3 hours. after this buff the turbines can last 4x longer.