### PR TITLE
Naqlines QFT Rebalance

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
 
-    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.195:dev')
+    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.197:dev')
     compile('com.github.GTNewHorizons:StructureLib:1.1.12:dev')
     compile("com.github.GTNewHorizons:ModularUI:1.0.31:dev")
     compile('com.github.GTNewHorizons:bartworks:0.5.131:dev')
@@ -27,7 +27,7 @@ dependencies {
 
 	runtime('com.github.GTNewHorizons:NewHorizonsCoreMod:1.9.116:dev')
 	runtime('com.github.GTNewHorizons:ForestryMC:4.5.6:dev')
-	runtime('com.github.GTNewHorizons:GTplusplus:1.7.169:dev')
+	runtime('com.github.GTNewHorizons:GTplusplus:1.7.176:dev')
 
     //compileOnly('com.github.GTNewHorizons:Avaritia:1.31)
 }

--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -57,7 +57,7 @@ public class NaquadahReworkRecipeLoader {
                         },
                         new FluidStack[] {},
                         new ItemStack[] {
-                            inertNaquadah.get(OrePrefixes.dust, 64),
+                            inertNaquadah.get(OrePrefixes.dust, 1),
                             Materials.Titanium.getDust(64),
                             Materials.Adamantium.getDust(64),
                             Materials.Gallium.getDust(64)
@@ -77,7 +77,7 @@ public class NaquadahReworkRecipeLoader {
                         new FluidStack[] {Materials.SulfuricAcid.getFluid(16000), Materials.Oxygen.getGas(100L)},
                         new FluidStack[] {wasteLiquid.getFluidOrGas(32000)},
                         new ItemStack[] {
-                            inertEnrichedNaquadah.get(OrePrefixes.dust, 64), Materials.Trinium.getDust(64),
+                            inertEnrichedNaquadah.get(OrePrefixes.dust, 1), Materials.Trinium.getDust(64),
                         },
                         new int[] {3300, 3300, 3300},
                         10 * 20,
@@ -97,7 +97,7 @@ public class NaquadahReworkRecipeLoader {
                         },
                         new FluidStack[] {},
                         new ItemStack[] {
-                            inertNaquadria.get(OrePrefixes.dust, 64),
+                            inertNaquadria.get(OrePrefixes.dust, 1),
                             Materials.Barium.getDust(64),
                             Materials.Indium.getDust(64),
                             ItemList.NaquadriaSupersolid.get(1)
@@ -108,77 +108,33 @@ public class NaquadahReworkRecipeLoader {
                         3);
                 // Activate Them
                 MyRecipeAdder.instance.addNeutronActivatorRecipe(
-                        new FluidStack[] {Materials.Nickel.getPlasma(2880)},
+                        new FluidStack[] {Materials.Nickel.getPlasma(144 * 16)},
                         new ItemStack[] {
-                            inertNaquadah.get(OrePrefixes.dust, 64),
-                            inertNaquadah.get(OrePrefixes.dust, 64),
-                            inertNaquadah.get(OrePrefixes.dust, 64),
-                            inertNaquadah.get(OrePrefixes.dust, 64),
-                            inertNaquadah.get(OrePrefixes.dust, 64),
-                            inertNaquadah.get(OrePrefixes.dust, 64),
+                            inertNaquadah.get(OrePrefixes.dust, 64), inertNaquadah.get(OrePrefixes.dust, 32)
                         },
-                        new FluidStack[] {Materials.Nickel.getMolten(2880)},
-                        new ItemStack[] {
-                            Materials.Naquadah.getDust(64),
-                            Materials.Naquadah.getDust(64),
-                            Materials.Naquadah.getDust(64),
-                            Materials.Naquadah.getDust(64),
-                            Materials.Naquadah.getDust(64),
-                            Materials.Naquadah.getDust(64),
-                            Materials.Naquadah.getDust(64),
-                            Materials.Naquadah.getDust(64),
-                            Materials.Naquadah.getDust(64),
-                        },
+                        new FluidStack[] {Materials.Naquadah.getMolten(144 * 9216)},
+                        new ItemStack[] {Materials.Nickel.getDust(16)},
                         2000,
                         600,
                         500);
                 MyRecipeAdder.instance.addNeutronActivatorRecipe(
-                        new FluidStack[] {Materials.Titanium.getPlasma(2880)},
+                        new FluidStack[] {Materials.Titanium.getPlasma(16 * 144)},
                         new ItemStack[] {
                             inertEnrichedNaquadah.get(OrePrefixes.dust, 64),
-                            inertEnrichedNaquadah.get(OrePrefixes.dust, 64),
-                            inertEnrichedNaquadah.get(OrePrefixes.dust, 64),
-                            inertEnrichedNaquadah.get(OrePrefixes.dust, 64),
-                            inertEnrichedNaquadah.get(OrePrefixes.dust, 64),
-                            inertEnrichedNaquadah.get(OrePrefixes.dust, 64),
+                            inertEnrichedNaquadah.get(OrePrefixes.dust, 32)
                         },
-                        new FluidStack[] {Materials.Titanium.getMolten(2880)},
-                        new ItemStack[] {
-                            Materials.NaquadahEnriched.getDust(64),
-                            Materials.NaquadahEnriched.getDust(64),
-                            Materials.NaquadahEnriched.getDust(64),
-                            Materials.NaquadahEnriched.getDust(64),
-                            Materials.NaquadahEnriched.getDust(64),
-                            Materials.NaquadahEnriched.getDust(64),
-                            Materials.NaquadahEnriched.getDust(64),
-                            Materials.NaquadahEnriched.getDust(64),
-                            Materials.NaquadahEnriched.getDust(64),
-                        },
+                        new FluidStack[] {Materials.NaquadahEnriched.getMolten(144 * 9216)},
+                        new ItemStack[] {Materials.Titanium.getDust(16)},
                         2000,
                         900,
                         850);
                 MyRecipeAdder.instance.addNeutronActivatorRecipe(
-                        new FluidStack[] {Materials.Americium.getPlasma(2880)},
+                        new FluidStack[] {Materials.Americium.getPlasma(144 * 16)},
                         new ItemStack[] {
-                            inertNaquadria.get(OrePrefixes.dust, 64),
-                            inertNaquadria.get(OrePrefixes.dust, 64),
-                            inertNaquadria.get(OrePrefixes.dust, 64),
-                            inertNaquadria.get(OrePrefixes.dust, 64),
-                            inertNaquadria.get(OrePrefixes.dust, 64),
-                            inertNaquadria.get(OrePrefixes.dust, 64),
+                            inertNaquadria.get(OrePrefixes.dust, 64), inertNaquadria.get(OrePrefixes.dust, 32)
                         },
-                        new FluidStack[] {Materials.Americium.getMolten(2880)},
-                        new ItemStack[] {
-                            Materials.Naquadria.getDust(64),
-                            Materials.Naquadria.getDust(64),
-                            Materials.Naquadria.getDust(64),
-                            Materials.Naquadria.getDust(64),
-                            Materials.Naquadria.getDust(64),
-                            Materials.Naquadria.getDust(64),
-                            Materials.Naquadria.getDust(64),
-                            Materials.Naquadria.getDust(64),
-                            Materials.Naquadria.getDust(64),
-                        },
+                        new FluidStack[] {Materials.Naquadria.getMolten(144 * 9216)},
+                        new ItemStack[] {Materials.Americium.getDust(16)},
                         2000,
                         1100,
                         1080);


### PR DESCRIPTION
With the help of @GDCloudstrike the QFT's skip for naqlines has been reworked a bit to require less plasma and a single neutron activator being able to keep up with a maxed out QFT to prevent multi spam for it.
Values:
![image](https://user-images.githubusercontent.com/76872108/210610945-0cec5ece-ed9b-4e84-bc72-556f8755dcda.png)
New Recipes:
Inert Naquadah
![image](https://user-images.githubusercontent.com/76872108/210611799-512ec425-284c-4825-95da-892c1cb14f84.png)
![image](https://user-images.githubusercontent.com/76872108/210611852-095f7649-5d07-4da8-ad90-3563d4e785bf.png)
Inert Enriched Naquadah
![image](https://user-images.githubusercontent.com/76872108/210611919-515eeacd-b604-4188-9a58-fb698829ad8f.png)
![image](https://user-images.githubusercontent.com/76872108/210611930-918a663d-b684-4f09-99f5-742e32d683a3.png)
Inert Naquadria
![image](https://user-images.githubusercontent.com/76872108/210611989-f5af9c57-922a-4d5c-b70b-e06b98319024.png)
![image](https://user-images.githubusercontent.com/76872108/210612012-10ce74b8-eff0-4582-8071-56fe7bf9081a.png)
