### PR TITLE
Fix tengam in component assemblyline

### DIFF
--- a/src/main/java/goodgenerator/loader/ComponentAssemblyLineRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/ComponentAssemblyLineRecipeLoader.java
@@ -172,6 +172,9 @@ public class ComponentAssemblyLineRecipeLoader {
                 if (data != null && data.mMaterial.mMaterial == Materials.SamariumMagnetic) {
                     input = GT_OreDictUnificator.get(data.mPrefix, Materials.Samarium, 1);
                     foundFluidStack = tryConvertItemStackToFluidMaterial(input);
+                } else if (data != null && data.mMaterial.mMaterial == Materials.TengamAttuned) {
+                    input = GT_OreDictUnificator.get(data.mPrefix, Materials.TengamPurified, 1);
+                    foundFluidStack = tryConvertItemStackToFluidMaterial(input);
                 }
 
                 if (foundFluidStack != null) {


### PR DESCRIPTION
The recipes were using molten attuned tengam which is not obtainable, changed it to purified tengam
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13516