### PR TITLE
Remove laser support for LEG

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1684218858
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -1276,12 +1276,14 @@ tasks.register('faq') {
     description = 'Prints frequently asked questions about building a project'
 
     doLast {
-        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
-            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
-            "The links can be found in repositories.gradle and build.gradle:repositories, " +
-            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
             "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
-            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
@@ -490,8 +490,9 @@ public class LargeEssentiaGenerator extends GT_MetaTileEntity_TooltipMultiBlockB
     protected GT_Multiblock_Tooltip_Builder createTooltip() {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Essentia Generator").addInfo("Controller block for the Large Essentia Generator")
-                .addInfo("Maybe some thaumaturages are upset by it. . .").addInfo("Transform essentia into energy!")
+                .addInfo("Maybe some Thaumaturges are upset by it. . .").addInfo("Transform Essentia into energy!")
                 .addInfo("The Diffusion Cell determines the highest hatch tier that the LEG can accept.")
+                .addInfo("Supports normal Dynamo Hatches or TecTech ones for up to 64A, but no Laser Hatches.")
                 .addInfo("You can find more information about this generator in the Thaumonomicon.")
                 .addInfo("The structure is too complex!").addInfo(BLUE_PRINT_INFO).addSeparator()
                 .addMaintenanceHatch("Hint block with dot 1").addInputHatch("Hint block with dot 1")

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
@@ -18,6 +18,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 
 import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_DynamoMulti;
+import com.github.technus.tectech.thing.metaTileEntity.hatch.GT_MetaTileEntity_Hatch_DynamoTunnel;
 import com.gtnewhorizon.structurelib.alignment.constructable.IConstructable;
 import com.gtnewhorizon.structurelib.alignment.constructable.ISurvivalConstructable;
 import com.gtnewhorizon.structurelib.structure.IItemSource;
@@ -79,7 +80,17 @@ public class LargeEssentiaGenerator extends GT_MetaTileEntity_TooltipMultiBlockB
         mEssentiaHatch.clear();
         return structureCheck_EM(mName, 4, 0, 4) && (mDynamoHatches.size() + eDynamoMulti.size()) == 1
                 && checkHatchTier()
+                && checkNoLaser()
                 && updateEssentiaHatchState();
+    }
+
+    private boolean checkNoLaser() {
+        for (GT_MetaTileEntity_Hatch_DynamoMulti tHatch : eDynamoMulti) {
+            if (tHatch instanceof GT_MetaTileEntity_Hatch_DynamoTunnel) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public boolean checkHatchTier() {


### PR DESCRIPTION
This PR removes laser hatch support from the LEG. Multiamp hatches up to 64A will continue to be allowed.

several reasons:

- The multi is aimed at HV-ZPM while laser is always considered UV+ technology.
- Laser support on energy production is extremely unbalanced if the numbers are not carefully considered and limitted by something else (which is not the case here)
- people have figured out how to make up to 136 billion EU/t in ZPM in the extreme. Of course several orders of magnitude less would already be a big problem. by comparison on gets around 1 million eu/t from a single fusion reactor running helium plasma with a large plasma turbine in ZPM. (64A ZPM for one LEG will still be 8 million eu/t!)
- closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13792