### PR TITLE
Buffing the LEG to UV for the LEG Laser nerf

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
@@ -179,7 +179,7 @@ public class LargeEssentiaGenerator extends GT_MetaTileEntity_TooltipMultiBlockB
                         x.mTierLimit = Math.max(x.mTierLimit, 6);
                     }, ofBlock(Loaders.essentiaCell, 2)), onElementPass(x -> {
                         x.mStableValue += 10;
-                        x.mTierLimit = Math.max(x.mTierLimit, 7);
+                        x.mTierLimit = Math.max(x.mTierLimit, 8);
                     },
                             ofBlock(Loaders.essentiaCell, 3))))
                     .addElement(


### PR DESCRIPTION
As has been discussed in #magic-dev in the face of chochom's laser nuke on the LEG, we need to update this value to have a max at either UV or UHV, I have set it here for UV but I'm open to suggestions