### PR TITLE
Buff CoAL recipe times to 48x base instead of 64x

### DIFF
--- a/src/main/java/goodgenerator/loader/ComponentAssemblyLineRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/ComponentAssemblyLineRecipeLoader.java
@@ -84,7 +84,7 @@ public class ComponentAssemblyLineRecipeLoader {
                             compactItems(fixedInputs, info.getRight()).toArray(new ItemStack[0]),
                             fixedFluids.toArray(new FluidStack[0]),
                             info.getLeft().get(OUTPUT_MULTIPLIER),
-                            recipe.mDuration * OUTPUT_MULTIPLIER,
+                            recipe.mDuration * INPUT_MULTIPLIER,
                             energy,
                             info.getRight());
                 }
@@ -144,7 +144,7 @@ public class ComponentAssemblyLineRecipeLoader {
                             fixedInputs.toArray(new ItemStack[0]),
                             fixedFluids.toArray(new FluidStack[0]),
                             info.getLeft().get(OUTPUT_MULTIPLIER), // The component output
-                            recipe.mDuration * OUTPUT_MULTIPLIER, // Takes as long as this many
+                            recipe.mDuration * INPUT_MULTIPLIER, // Takes as long as this many
                             recipe.mEUt,
                             info.getRight()); // Casing tier
                 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13953

Currently CoALs become a spam multi in endgame. The server I play on has ~40 at 8T eu/t each and they still bottleneck many crafts. This attempts to alleviate some of the spam without trivializing component crafts by reducing time multiplier over base to 48x from 64x.