### PR TITLE
Fix crafting input hatches texture in PrAss

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/PreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/PreciseAssembler.java
@@ -364,6 +364,9 @@ public class PreciseAssembler extends GT_MetaTileEntity_ExtendedPowerMultiBlockB
     }
 
     public void reUpdate(int texture) {
+        for (IDualInputHatch hatch : mDualInputHatches) {
+            hatch.updateTexture(texture);
+        }
         for (GT_MetaTileEntity_Hatch hatch : mInputHatches) {
             hatch.updateTexture(texture);
         }


### PR DESCRIPTION
Their texture were sometimes not properly updated to fit the casing.