### PR TITLE
Extract using AEFluidStack, not FluidStack

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/GTMetaTileEntity/YOTTAHatch.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/GTMetaTileEntity/YOTTAHatch.java
@@ -181,7 +181,7 @@ public class YOTTAHatch extends GT_MetaTileEntity_Hatch implements IGridProxyabl
     public IAEFluidStack extractItems(IAEFluidStack request, Actionable mode, BaseActionSource src) {
         IAEFluidStack ready = drain(null, request, false);
         if (ready != null) {
-            if (mode.equals(Actionable.MODULATE)) drain(null, request.getFluidStack(), true);
+            if (mode.equals(Actionable.MODULATE)) drain(null, ready, true);
             return ready;
         } else return null;
     }


### PR DESCRIPTION
Using FluidStack limits extraction to INT32_MAX; use AEFluidStack to extract up to INT64_MAX.

Close https://github.com/GTNewHorizons/Dupes-Exploits-GTNH/issues/97