### PR TITLE
Don't consume multiple amps for Precise Assembler if only one normal energy hatch is used

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/PreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/PreciseAssembler.java
@@ -229,8 +229,9 @@ public class PreciseAssembler extends GT_MetaTileEntity_ExtendedPowerMultiBlockB
 
     @Override
     protected void setProcessingLogicPower(ProcessingLogic logic) {
+        boolean useSingleAmp = mEnergyHatches.size() == 1 && mExoticEnergyHatches.size() == 0;
         logic.setAvailableVoltage(getMachineVoltageLimit());
-        logic.setAvailableAmperage(getMaxInputAmps());
+        logic.setAvailableAmperage(useSingleAmp ? 1 : getMaxInputAmps());
     }
 
     @Override


### PR DESCRIPTION
Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14053