### PR TITLE
Add a way to make more Tiberium using Naquadah Gas

### DIFF
--- a/src/main/java/goodgenerator/loader/RecipeLoader_02.java
+++ b/src/main/java/goodgenerator/loader/RecipeLoader_02.java
@@ -1,5 +1,7 @@
 package goodgenerator.loader;
 
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAutoclaveRecipes;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -16,7 +18,6 @@ import goodgenerator.util.ItemRefer;
 import goodgenerator.util.MyRecipeAdder;
 import gregtech.api.enums.*;
 import gregtech.api.util.*;
-import gregtech.api.util.GT_ModHandler;
 import gtPlusPlus.core.item.chemistry.GenericChem;
 import gtPlusPlus.core.material.ALLOY;
 import gtPlusPlus.core.material.ELEMENT;
@@ -664,13 +665,12 @@ public class RecipeLoader_02 {
                 100,
                 480);
 
-        GT_Values.RA.addAutoclaveRecipe(
-                WerkstoffLoader.Tiberium.get(OrePrefixes.dust, 1),
-                MyMaterial.naquadahGas.getFluidOrGas(250),
-                WerkstoffLoader.Tiberium.get(OrePrefixes.gem, 1),
-                10000,
-                400,
-                480);
+        GT_Values.RA.stdBuilder().itemInputs(WerkstoffLoader.Tiberium.get(OrePrefixes.dust, 1))
+                .itemOutputs(
+                        WerkstoffLoader.Tiberium.get(OrePrefixes.gem, 1),
+                        WerkstoffLoader.Tiberium.get(OrePrefixes.gem, 1))
+                .outputChances(10000, 2000).fluidInputs(MyMaterial.naquadahGas.getFluidOrGas(250)).noFluidOutputs()
+                .duration(400).eut(TierEU.RECIPE_HV).addTo(sAutoclaveRecipes);
 
         GT_Values.RA.addChemicalBathRecipe(
                 Materials.Firestone.getGems(1),


### PR DESCRIPTION
Currently the only two sources of Tiberium are Void Miners or Space Mining (Or converting diamonds/firestone using Naquadah Fuels but that defeats the point). Tiberium is the primary bottleneck of Naqfuel, requiring dedicated space elevators of nothing but Space Mining modules to keep up with the demand.

This PR makes the Tiberium Dust + Naquadah Gas -> Tiberium Crystal recipe produce 1.2 crystals instead of 1.0, essentially allowing the player to convert Naquadah Gas into more Tiberium. Naquadah gas is already a fairly useless byproduct of Naqfuel, so this would help players keep up with the demand.

![image](https://github.com/GlodBlock/GoodGenerator/assets/69092953/51d5accf-4cc5-4a5a-9e42-63cd529a6b8a)
