### PR TITLE
Buff Mark I and Mark II naquadah fuels

### DIFF
--- a/src/main/java/goodgenerator/main/GG_Config_Loader.java
+++ b/src/main/java/goodgenerator/main/GG_Config_Loader.java
@@ -14,7 +14,7 @@ public class GG_Config_Loader {
     public static int LiquidAirConsumptionPerSecond = 2400;
     public static int[] NaquadahFuelVoltage = new int[] { 12960, 2200, 32400, 975000, 2300000, 9511000, 88540000,
             399576000 };
-    public static int[] NaquadahFuelTime = new int[] { 100, 500, 150, 20, 20, 80, 100, 160 };
+    public static int[] NaquadahFuelTime = new int[] { 100, 500, 150, 80, 80, 80, 100, 160 };
     public static int[] CoolantEfficiency = new int[] { 500, 275, 150, 105 };
     public static int[] ExcitedLiquidCoe = new int[] { 64, 16, 4, 3, 2 };
     public static boolean EnableNaquadahRework = true;

--- a/src/main/java/goodgenerator/main/GG_Config_Loader.java
+++ b/src/main/java/goodgenerator/main/GG_Config_Loader.java
@@ -14,7 +14,7 @@ public class GG_Config_Loader {
     public static int LiquidAirConsumptionPerSecond = 2400;
     public static int[] NaquadahFuelVoltage = new int[] { 12960, 2200, 32400, 975000, 2300000, 9511000, 88540000,
             399576000 };
-    public static int[] NaquadahFuelTime = new int[] { 100, 500, 150, 80, 80, 80, 100, 160 };
+    public static int[] NaquadahFuelTime = new int[] { 100, 500, 150, 60, 70, 80, 100, 160 };
     public static int[] CoolantEfficiency = new int[] { 500, 275, 150, 105 };
     public static int[] ExcitedLiquidCoe = new int[] { 64, 16, 4, 3, 2 };
     public static boolean EnableNaquadahRework = true;


### PR DESCRIPTION
Increases Mark I burn time in the reactor by 200%, from 20 ticks to 60 ticks, essentially buffing it by 200%.
Does the same for Mark 2 by 250%, 20 ticks to 70 ticks.

Nobody uses the Mk1 and Mk2 fuels because the logistical complexity of setting up a full naquadah line and additional processing for the fuels themselves is vastly under-rewarded by the current fuel values, when the player can just do normal fusion for helium/tin plasma to get roughly equivalent amounts of power for no infrastructure investment.

Buffing the MKI and MKII numbers should make at least some players consider the early tier naquadah fuels.

As this affects balance:

**What goal is this change trying to achieve? What tier is it targeting?**
Naquadah Fuel MKI and MKII have such a massive upfront cost compared to other same-tier power generation options, rendering them unrewarding to make as you can get the same numbers with one tenth of the effort. This buff will make them a more attractive option in the ZPM-UV tiers. They will still be held back massively by the lack of reliable source of all the materials required for the naquadah fuels in these tiers.
**What side effects does this have on other lines/systems? How does it change the game meta?**
MKI depleted fuel provides trace amounts of europium, which might become a nice bonus for making Americium for those that pursue the naquadah fuels. It is unlikely to become dominant power meta due to the complexity compared to, for example, extreme heat exchangers, but might see some players trying out naquadah fuels earlier.
**If relevant, do you have any metrics or a spreadsheet/visualization explaining your change? If it is a new multiblock, could you provide a picture of it and/or a practical setup? This may help us understand it better.**
None
**Is this change made in expectation or in tandem with another unwritten or unmerged change coming later?**
This change is fully isolated as the rest of naqudah fuel changes only primarily apply to MKIII and above.