### PR TITLE
No amperage OC for PrAss

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/PreciseAssembler.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/PreciseAssembler.java
@@ -232,6 +232,7 @@ public class PreciseAssembler extends GT_MetaTileEntity_ExtendedPowerMultiBlockB
         boolean useSingleAmp = mEnergyHatches.size() == 1 && mExoticEnergyHatches.size() == 0;
         logic.setAvailableVoltage(getMachineVoltageLimit());
         logic.setAvailableAmperage(useSingleAmp ? 1 : getMaxInputAmps());
+        logic.setAmperageOC(false);
     }
 
     @Override


### PR DESCRIPTION
the code was already mostly correct, but a simple flag was missing.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14333

now works correctly (tested UV recipe with 64A IV hatch with IV or UV casings, both dont start now):
![image](https://github.com/GTNewHorizons/GoodGenerator/assets/40274384/a1d80c56-7b04-42f4-a623-d9ceb7e39a06)
