### PR TITLE
Essentia smelter parallel

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaSmeltery.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaSmeltery.java
@@ -310,7 +310,8 @@ public class LargeEssentiaSmeltery extends GT_MetaTileEntity_TooltipMultiBlockBa
                 consumedItems = maxParallels;
                 break;
             } else {
-                this.mOutputAspects.add(getEssentia(itemStack, maxParallels));
+                this.mOutputAspects.add(getEssentia(itemStack, maxParallels - consumedItems));
+                itemStack.stackSize -= maxParallels - consumedItems;
                 consumedItems = maxParallels;
                 break;
             }

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaSmeltery.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaSmeltery.java
@@ -70,7 +70,8 @@ public class LargeEssentiaSmeltery extends GT_MetaTileEntity_TooltipMultiBlockBa
     private static final int MAX_CONFIGURABLE_LENGTH = MAX_STRUCTURE_LENGTH - DEFAULT_STRUCTURE_LENGTH;
 
     private static final int RECIPE_DURATION = 32;
-    private static final long RECIPE_EUT = 480;
+    private static final int RECIPE_EUT = 480;
+    private static final int MAX_PARALLELS = 64;
     private static final float NODE_COST_MULTIPLIER = 1.15f;
 
     public AspectList mOutputAspects = new AspectList();
@@ -129,6 +130,7 @@ public class LargeEssentiaSmeltery extends GT_MetaTileEntity_TooltipMultiBlockBa
                 && this.mInputBusses.size() >= 1
                 && this.mEssentiaOutputHatches.size() >= 1) {
             this.mParallel = Math.floor(this.mParallel += 1 << this.pTier);
+            this.mParallel = Math.min(this.mParallel, MAX_PARALLELS);
             return true;
         }
         return false;
@@ -291,7 +293,7 @@ public class LargeEssentiaSmeltery extends GT_MetaTileEntity_TooltipMultiBlockBa
 
         if (tInputList.size() == 0) return CheckRecipeResultRegistry.NO_RECIPE;
 
-        int maxParallels = (int) Math.min(this.mParallel, (double) getMaxInputEnergy_EM() / RECIPE_EUT);
+        int maxParallels = (int) Math.min(this.mParallel, getMaxInputEnergy_EM() / (double) RECIPE_EUT);
         int consumedItems = 0;
         for (int i = tInputList.size() - 1; i >= 0; i--) {
             ItemStack itemStack = tInputList.get(i);


### PR DESCRIPTION
Addresses [#14214](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14214)

Perfect OC made parallels pointless unless you're processing items at <1 tick, which only happens at UV+ for 1 aspect items.

This replaces perfect OC with proper parallel, up to 64 as per the Thaumonomicon, with imperfect OC applying after.