### PR TITLE
Add more solidifier recipies for metastable oganesson

### DIFF
--- a/src/main/java/goodgenerator/items/MyMaterial.java
+++ b/src/main/java/goodgenerator/items/MyMaterial.java
@@ -1244,7 +1244,7 @@ public class MyMaterial implements Runnable {
             new Werkstoff.Stats().setBlastFurnace(true).setProtons(118).setMass(294).setMeltingPoint(11000),
             Werkstoff.Types.ELEMENT,
             new Werkstoff.GenerationFeatures().onlyDust().addMolten().addMetalItems().addCraftingMetalWorkingItems()
-                    .addMultipleIngotMetalWorkingItems(),
+                    .addMultipleIngotMetalWorkingItems().addMetaSolidifierRecipes(),
             OffsetID + 110,
             TextureSet.SET_SHINY);
 


### PR DESCRIPTION
Allows metastable og to be solidifed into screws, bolts, rings etc.
You need a fair amount of screws and there's not really a reason why you shouldn't be able to solidfy into that.