### PR TITLE
Stop maintenance issues cropping up on fuel refinery.

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/FuelRefineFactory.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/FuelRefineFactory.java
@@ -71,6 +71,11 @@ public class FuelRefineFactory extends GT_MetaTileEntity_TooltipMultiBlockBase_E
     }
 
     @Override
+    public boolean doRandomMaintenanceDamage() {
+        return true;
+    }
+
+    @Override
     public void construct(ItemStack itemStack, boolean hintsOnly) {
         structureBuild_EM(mName, 7, 12, 1, itemStack, hintsOnly);
     }


### PR DESCRIPTION
The multi passes structure checks without a maintenance hatch and clears all maintenance issues when placed, but does not prevent them from reappearing during processing. This is what e.g. the TecTech active transformer does to avoid maintenance issues.