### PR TITLE
Compact fusion structure fixes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,8 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.45:dev')
-    api('com.github.GTNewHorizons:bartworks:0.9.4:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.60:dev')
+    api('com.github.GTNewHorizons:bartworks:0.9.7:dev')
     implementation('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     implementation('com.github.GTNewHorizons:GTplusplus:1.11.19:dev')
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,16 +50,16 @@ enableGenericInjection = false
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = goodgenerator.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
-gradleTokenModId = GRADLETOKEN_MODID
+gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
-gradleTokenModName = GRADLETOKEN_MODNAME
+gradleTokenModName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -67,7 +67,7 @@ gradleTokenModName = GRADLETOKEN_MODNAME
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = GoodGenerator.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
@@ -188,4 +188,4 @@ curseForgeRelations =
 # ideaCheckSpotlessOnBuild = true
 
 # Non-GTNH properties
-gradleTokenGroupName = GRADLETOKEN_GROUPNAME
+#gradleTokenGroupName = GRADLETOKEN_GROUPNAME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.9'
 }
 
 

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -2,6 +2,7 @@ package goodgenerator.blocks.tileEntity.base;
 
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.enums.Textures.BlockIcons.*;
+import static gregtech.api.util.GT_StructureUtility.filterByMTETier;
 import static gregtech.api.util.GT_StructureUtility.ofFrame;
 import static gregtech.api.util.GT_Utility.filterValidMTEs;
 
@@ -82,17 +83,20 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
                             lazy(
                                     x -> GT_HatchElementBuilder.<LargeFusionComputer>builder()
                                             .atLeast(
-                                                    GT_HatchElement.InputHatch,
-                                                    GT_HatchElement.OutputHatch,
-                                                    GT_HatchElement.InputBus)
+                                                    GT_HatchElement.InputHatch.or(GT_HatchElement.InputBus),
+                                                    GT_HatchElement.OutputHatch)
                                             .adder(LargeFusionComputer::addFluidIO).casingIndex(x.textureIndex()).dot(1)
+                                            .hatchItemFilterAnd(
+                                                    x2 -> filterByMTETier(x2.hatchTier(), Integer.MAX_VALUE))
                                             .buildAndChain(x.getGlassBlock(), x.getGlassMeta())))
                     .addElement(
                             'E',
                             lazy(
                                     x -> GT_HatchElementBuilder.<LargeFusionComputer>builder()
-                                            .atLeast(HatchElement.EnergyMulti.or(GT_HatchElement.Energy))
+                                            .anyOf(HatchElement.EnergyMulti.or(GT_HatchElement.Energy))
                                             .adder(LargeFusionComputer::addEnergyInjector).casingIndex(x.textureIndex())
+                                            .hatchItemFilterAnd(
+                                                    x2 -> filterByMTETier(x2.hatchTier(), Integer.MAX_VALUE))
                                             .dot(2).buildAndChain(x.getCasingBlock(), x.getCasingMeta())))
                     .addElement('F', lazy(x -> ofFrame(x.getFrameBox()))).build();
         }

--- a/src/main/java/goodgenerator/main/GoodGenerator.java
+++ b/src/main/java/goodgenerator/main/GoodGenerator.java
@@ -13,6 +13,7 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import goodgenerator.Tags;
 import goodgenerator.common.CommonProxy;
 import goodgenerator.crossmod.thaumcraft.Research;
 import goodgenerator.items.MyMaterial;
@@ -32,9 +33,9 @@ import goodgenerator.tabs.MyTabs;
                 + "after:dreamcraft;")
 public final class GoodGenerator {
 
-    public static final String MOD_ID = "GRADLETOKEN_MODID";
-    public static final String MOD_NAME = "GRADLETOKEN_MODNAME";
-    public static final String VERSION = "GRADLETOKEN_VERSION";
+    public static final String MOD_ID = "GoodGenerator";
+    public static final String MOD_NAME = "Good Generator";
+    public static final String VERSION = Tags.VERSION;
 
     public static final CreativeTabs GG = new MyTabs("Good Generator");
 


### PR DESCRIPTION
1. Change to `GT_HatchElement.InputHatch.or(GT_HatchElement.InputBus)` instead of adding the input bus separately. This still allows for the crafting input bus and is mostly done to prevent the BlockRenderer preview from placing a gazillion input busses. 
2. Adds hatchItemFilterAnd to make survival autobuild use the required tier busses or higher. (Might be controlled by the adder as well but not for the preview)
3. Change the energy hatches to use anyOf instead of atLeast. This allows survival autobuild to place all 32 energy hatches provided they are in your inventory. I don't believe there's any use case where placing only 1 hatch is desired.
~~4. Bans input busses completely as they don't have any purpose. This does not affect the crafting input bus.~~