### PR TITLE
Fix naq nugget recipe

### DIFF
--- a/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/NaquadahReworkRecipeLoader.java
@@ -437,7 +437,7 @@ public class NaquadahReworkRecipeLoader {
                 .eut(TierEU.RECIPE_EV).addTo(UniversalChemical);
 
         GT_Values.RA.stdBuilder().itemInputs(naquadahEarth.get(OrePrefixes.dust, 2), GT_Utility.getIntegratedCircuit(2))
-                .fluidInputs(Materials.Nitrogen.getGas(1000)).itemOutputs(ItemList.Circuit_Silicon_Ingot3.get(1))
+                .fluidInputs(Materials.Nitrogen.getGas(1000)).itemOutputs(Materials.Naquadah.getNuggets(1))
                 .duration(2 * MINUTES).eut(TierEU.RECIPE_IV).metadata(COIL_HEAT, 5000).addTo(blastFurnaceRecipes);
 
         // C2H4 + H2O(g) = C2H6O


### PR DESCRIPTION
Fixes the naq nugget recipe.

It was broken in https://github.com/GTNewHorizons/GoodGenerator/pull/232. Just got mixed up with another recipe by mistake.

Now all good:
![image](https://github.com/GTNewHorizons/GoodGenerator/assets/40274384/1fafcabe-ea04-4888-8217-45427c80110d)
