### PR TITLE
Fix compact fusion tierskip, wrong OC and scanner info

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -4,7 +4,7 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.enums.Textures.BlockIcons.*;
 import static gregtech.api.util.GT_StructureUtility.filterByMTETier;
 import static gregtech.api.util.GT_StructureUtility.ofFrame;
-import static gregtech.api.util.GT_Utility.filterValidMTEs;
+import static gregtech.api.util.GT_Utility.*;
 
 import java.util.List;
 
@@ -449,7 +449,11 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
             @NotNull
             @Override
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
-                return super.createOverclockCalculator(recipe).limitOverclockCount(overclock(recipe.mSpecialValue));
+                int overclockCount = overclock(recipe.mSpecialValue);
+                if (GT_Values.VP[LargeFusionComputer.this.tier()] <= roundUpVoltage(recipe.mEUt)) {
+                    overclockCount = 0;
+                }
+                return super.createOverclockCalculator(recipe).limitOverclockCount(overclockCount);
             }
 
             @NotNull

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -455,7 +455,8 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
             @NotNull
             @Override
             protected CheckRecipeResult validateRecipe(@NotNull GT_Recipe recipe) {
-                if (!mRunningOnLoad && recipe.mSpecialValue > maxEUStore()) {
+                if (!mRunningOnLoad && recipe.mSpecialValue > maxEUStore()
+                        || GT_Values.VP[LargeFusionComputer.this.tier()] < recipe.mEUt) {
                     return CheckRecipeResultRegistry.insufficientStartupPower(recipe.mSpecialValue);
                 }
                 maxParallel = getMaxPara() * extraPara(recipe.mSpecialValue);

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -588,7 +588,7 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
                         + EnumChatFormatting.RESET,
                 StatCollector.translateToLocal("GT5U.fusion.req") + ": "
                         + EnumChatFormatting.RED
-                        + GT_Utility.formatNumbers(lEUt)
+                        + GT_Utility.formatNumbers(-lEUt)
                         + EnumChatFormatting.RESET
                         + "EU/t",
                 StatCollector.translateToLocal("GT5U.multiblock.energy") + ": "

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -4,7 +4,8 @@ import static com.gtnewhorizon.structurelib.structure.StructureUtility.*;
 import static gregtech.api.enums.Textures.BlockIcons.*;
 import static gregtech.api.util.GT_StructureUtility.filterByMTETier;
 import static gregtech.api.util.GT_StructureUtility.ofFrame;
-import static gregtech.api.util.GT_Utility.*;
+import static gregtech.api.util.GT_Utility.filterValidMTEs;
+import static gregtech.api.util.GT_Utility.roundUpVoltage;
 
 import java.util.List;
 


### PR DESCRIPTION
Fixes three bugs regarding compact fusion reactors.

The first and major fix is that compact fusion reactors now cannot skip fusion tiers, so for example a mk4 compact cannot do mk5 fusion recipes. 

The second, smaller fix, is that compacts can no longer overclock on-tier recipes (this was only a thing for mk5s).

The third fix is that the required eu/t in the scanner info no longer displays a negative number.
![image](https://github.com/GTNewHorizons/GoodGenerator/assets/93287602/11574854-bfe0-436e-be1f-09dd79161af4)
