### PR TITLE
CoALs: Add missing styrene-butadiene variants for AssLine recipes.

### DIFF
--- a/src/main/java/goodgenerator/loader/ComponentAssemblyLineRecipeLoader.java
+++ b/src/main/java/goodgenerator/loader/ComponentAssemblyLineRecipeLoader.java
@@ -176,6 +176,21 @@ public class ComponentAssemblyLineRecipeLoader {
                             recipe.mDuration * INPUT_MULTIPLIER, // Takes as long as this many
                             recipe.mEUt,
                             info.getRight()); // Casing tier
+
+                    // Add a second recipe using Styrene-Butadiene
+                    // Rubber instead of Silicone Rubber.
+                    // This relies on silicone rubber being first in
+                    // @allSyntheticRubber so it's quite fragile, but
+                    // it's also the least invasive change.
+                    if (swapSiliconeForStyreneButadiene(fixedFluids)) {
+                        MyRecipeAdder.instance.addComponentAssemblyLineRecipe(
+                                fixedInputs.toArray(new ItemStack[0]),
+                                fixedFluids.toArray(new FluidStack[0]),
+                                info.getLeft().get(OUTPUT_MULTIPLIER), // The component output
+                                recipe.mDuration * INPUT_MULTIPLIER, // Takes as long as this many
+                                recipe.mEUt,
+                                info.getRight()); // Casing tier
+                    }
                 }
             }
         });
@@ -441,5 +456,16 @@ public class ComponentAssemblyLineRecipeLoader {
             // in their assline recipes and each CoAl recipe has 48x recipe inputs
             fluidInputs.add(MaterialsUEVplus.Eternity.getMolten(mhdcsmAmount - 576 * 48));
         }
+    }
+
+    private static boolean swapSiliconeForStyreneButadiene(ArrayList<FluidStack> fluidInputs) {
+        for (int i = 0; i < fluidInputs.size(); i++) {
+            FluidStack fluidstack = fluidInputs.get(i);
+            if (fluidstack.getFluid().equals(FluidRegistry.getFluid("molten.silicone"))) {
+                fluidInputs.set(i, FluidRegistry.getFluidStack("molten.styrenebutadienerubber", fluidstack.amount));
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Post-QFT, I am left with a surfeit of Styrene-Butadiene rubber.

The Assembly Line recipes for pumps allow both Styrene-Butadiene Rubber rings and Silicone Rubber rings, similarly the conveyors allow for either plate, using the `@ringAnySyntheticRubber` or `@plateAnySyntheticRubber` oredict entries. But the code to derive Component Assembly Line recipes only use the first oredict entry, so in the CoAL I can only use Silicone Rubber.

This changes that in the least invasive way I could see. As noted in the comment, it is a bit fragile, i.e., if the ordering in the oredict list changes it will probably stop working again. If y'all have alternative suggestions I'm all ears :-)

Screenshots of a couple of the added recipes:

<img width="596" alt="2024-02-27_16 50 20" src="https://github.com/GTNewHorizons/GoodGenerator/assets/169107/ef0e5d64-1c68-40d1-9cef-712a1c5c43ca">
<img width="344" alt="2024-02-27_16 49 32" src="https://github.com/GTNewHorizons/GoodGenerator/assets/169107/16a9f29e-24ff-4998-83fd-9031bd13f2fa">
