### PR TITLE
Add missing compact mk5 OC

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -454,6 +454,11 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
                 if (GT_Values.VP[LargeFusionComputer.this.tier()] <= roundUpVoltage(recipe.mEUt)) {
                     overclockCount = 0;
                 }
+                // If it's a mk5 reactor and no startupOC has been performed but the recipe is mk4, then perform 1 OC
+                if (LargeFusionComputer.this.tier() == 10 && overclockCount == 0
+                        && roundUpVoltage(recipe.mEUt) < GT_Values.VP[LargeFusionComputer.this.tier()]) {
+                    overclockCount++;
+                }
                 return super.createOverclockCalculator(recipe).limitOverclockCount(overclockCount);
             }
 


### PR DESCRIPTION
There is an edge case where a mk4 recipe has too high of a startup cost to get OCd by a mk5 compact, even though the recipe voltage would allow for it. This PR fixes that by adding a check for this exact scenario, which adds 1 OC.

Rhugnor was such an edge case and was the exact same speed in a mk4&mk5 compact, which is obviously wrong. With this PR it receives 1 OC as expected (going from 25.6 to 6.4 seconds)
![image](https://github.com/GTNewHorizons/GoodGenerator/assets/93287602/dbac1409-1647-4085-8127-dee80d603e31)
