### PR TITLE
Fix compact fusions

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer1.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer1.java
@@ -42,10 +42,10 @@ public class LargeFusionComputer1 extends LargeFusionComputer {
         tt.addMachineType("Fusion Reactor").addInfo("Millions of nuclear.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-I Prototype.")
                 .addInfo(
-                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                        EnumChatFormatting.AQUA + GT_Utility.formatNumbers(getSingleHatchPower())
                                 + EnumChatFormatting.GRAY
-                                + "EU/t and "
-                                + EnumChatFormatting.BLUE
+                                + " EU/t and "
+                                + EnumChatFormatting.AQUA
                                 + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
                                 + "M"
                                 + EnumChatFormatting.GRAY

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer1.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer1.java
@@ -41,9 +41,22 @@ public class LargeFusionComputer1 extends LargeFusionComputer {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Fusion Reactor").addInfo("Millions of nuclear.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-I Prototype.")
-                .addInfo("131,072EU/t and 5M EU capacity per Energy Hatch")
+                .addInfo(
+                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                                + EnumChatFormatting.GRAY
+                                + "EU/t and "
+                                + EnumChatFormatting.BLUE
+                                + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
+                                + "M"
+                                + EnumChatFormatting.GRAY
+                                + " EU capacity per Energy Hatch")
                 .addInfo("If the recipe has a startup cost greater than the")
                 .addInfo("number of energy hatches * cap, you can't do it")
+                .addInfo(
+                        "If the recipe requires a voltage tier over "
+                                + GT_Utility.getColoredTierNameFromTier((byte) tier())
+                                + EnumChatFormatting.GRAY
+                                + " , you can't do it either")
                 .addInfo("Make sure the whole structure is built in the 3x3")
                 .addInfo("chunk area of the ring center (not controller).").addInfo("It can run 64x recipes at most.")
                 .addInfo(
@@ -70,11 +83,6 @@ public class LargeFusionComputer1 extends LargeFusionComputer {
     @Override
     public int tier() {
         return 6;
-    }
-
-    @Override
-    public long maxEUStore() {
-        return 160008000L * (Math.min(32, this.mEnergyHatches.size() + this.eEnergyMulti.size())) / 32L;
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer1.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer1.java
@@ -146,11 +146,6 @@ public class LargeFusionComputer1 extends LargeFusionComputer {
     }
 
     @Override
-    public int tierOverclock() {
-        return 1;
-    }
-
-    @Override
     public String[] getStructureDescription(ItemStack stackSize) {
         return DescTextLocalization.addText("LargeFusion1.hint", 9);
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer2.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer2.java
@@ -42,10 +42,10 @@ public class LargeFusionComputer2 extends LargeFusionComputer {
         tt.addMachineType("Fusion Reactor").addInfo("Millions of nuclear.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-II.")
                 .addInfo(
-                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                        EnumChatFormatting.AQUA + GT_Utility.formatNumbers(getSingleHatchPower())
                                 + EnumChatFormatting.GRAY
-                                + "EU/t and "
-                                + EnumChatFormatting.BLUE
+                                + " EU/t and "
+                                + EnumChatFormatting.AQUA
                                 + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
                                 + "M"
                                 + EnumChatFormatting.GRAY

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer2.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer2.java
@@ -147,11 +147,6 @@ public class LargeFusionComputer2 extends LargeFusionComputer {
     }
 
     @Override
-    public int tierOverclock() {
-        return 2;
-    }
-
-    @Override
     public String[] getStructureDescription(ItemStack stackSize) {
         return DescTextLocalization.addText("LargeFusion2.hint", 9);
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer2.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer2.java
@@ -41,12 +41,25 @@ public class LargeFusionComputer2 extends LargeFusionComputer {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Fusion Reactor").addInfo("Millions of nuclear.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-II.")
-                .addInfo("524,288EU/t and 10M EU capacity per Energy Hatch")
+                .addInfo(
+                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                                + EnumChatFormatting.GRAY
+                                + "EU/t and "
+                                + EnumChatFormatting.BLUE
+                                + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
+                                + "M"
+                                + EnumChatFormatting.GRAY
+                                + " EU capacity per Energy Hatch")
                 .addInfo("If the recipe has a startup cost greater than the")
                 .addInfo("number of energy hatches * cap, you can't do it")
+                .addInfo(
+                        "If the recipe requires a voltage tier over "
+                                + GT_Utility.getColoredTierNameFromTier((byte) tier())
+                                + EnumChatFormatting.GRAY
+                                + " , you can't do it either")
                 .addInfo("Make sure the whole structure is built in the 3x3")
                 .addInfo("chunk area of the ring center (not controller).")
-                .addInfo("Startup < 160,000,000 EU: 128x Parallel").addInfo("Startup < 320,000,000 EU: 64x Parallel")
+                .addInfo("Startup < 160,000,000 EU: 128x Parallel").addInfo("Startup >= 160,000,000 EU: 64x Parallel")
                 .addInfo(
                         "Support" + EnumChatFormatting.BLUE
                                 + " Tec"
@@ -71,11 +84,6 @@ public class LargeFusionComputer2 extends LargeFusionComputer {
     @Override
     public int tier() {
         return 7;
-    }
-
-    @Override
-    public long maxEUStore() {
-        return 320006000L * (Math.min(32, this.mEnergyHatches.size() + this.eEnergyMulti.size())) / 32L;
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer3.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer3.java
@@ -148,11 +148,6 @@ public class LargeFusionComputer3 extends LargeFusionComputer {
     }
 
     @Override
-    public int tierOverclock() {
-        return 4;
-    }
-
-    @Override
     public String[] getStructureDescription(ItemStack stackSize) {
         return DescTextLocalization.addText("LargeFusion3.hint", 9);
     }

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer3.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer3.java
@@ -41,13 +41,26 @@ public class LargeFusionComputer3 extends LargeFusionComputer {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Fusion Reactor").addInfo("Millions of nuclear.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-III.")
-                .addInfo("1,572,864EU/t and 20M EU capacity per Energy Hatch")
+                .addInfo(
+                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                                + EnumChatFormatting.GRAY
+                                + "EU/t and "
+                                + EnumChatFormatting.BLUE
+                                + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
+                                + "M"
+                                + EnumChatFormatting.GRAY
+                                + " EU capacity per Energy Hatch")
                 .addInfo("If the recipe has a startup cost greater than the")
                 .addInfo("number of energy hatches * cap, you can't do it")
+                .addInfo(
+                        "If the recipe requires a voltage tier over "
+                                + GT_Utility.getColoredTierNameFromTier((byte) tier())
+                                + EnumChatFormatting.GRAY
+                                + " , you can't do it either")
                 .addInfo("Make sure the whole structure is built in the 3x3")
                 .addInfo("chunk area of the ring center (not controller).")
                 .addInfo("Startup < 160,000,000 EU: 192x Parallel").addInfo("Startup < 320,000,000 EU: 128x Parallel")
-                .addInfo("Startup < 640,000,000 EU: 64x Parallel")
+                .addInfo("Startup >= 320,000,000 EU: 64x Parallel")
                 .addInfo(
                         "Support" + EnumChatFormatting.BLUE
                                 + " Tec"
@@ -72,11 +85,6 @@ public class LargeFusionComputer3 extends LargeFusionComputer {
     @Override
     public int tier() {
         return 8;
-    }
-
-    @Override
-    public long maxEUStore() {
-        return 640060000L * (Math.min(32, this.mEnergyHatches.size() + this.eEnergyMulti.size())) / 32L;
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer3.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer3.java
@@ -42,10 +42,10 @@ public class LargeFusionComputer3 extends LargeFusionComputer {
         tt.addMachineType("Fusion Reactor").addInfo("Millions of nuclear.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-III.")
                 .addInfo(
-                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                        EnumChatFormatting.AQUA + GT_Utility.formatNumbers(getSingleHatchPower())
                                 + EnumChatFormatting.GRAY
-                                + "EU/t and "
-                                + EnumChatFormatting.BLUE
+                                + " EU/t and "
+                                + EnumChatFormatting.AQUA
                                 + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
                                 + "M"
                                 + EnumChatFormatting.GRAY

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer4.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer4.java
@@ -45,9 +45,22 @@ public class LargeFusionComputer4 extends LargeFusionComputerPP {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Fusion Reactor").addInfo("Galaxy Collapse.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-IV Prototype.")
-                .addInfo("33,554,432EU/t and 80M EU capacity per Energy Hatch")
+                .addInfo(
+                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                                + EnumChatFormatting.GRAY
+                                + "EU/t and "
+                                + EnumChatFormatting.BLUE
+                                + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
+                                + "M"
+                                + EnumChatFormatting.GRAY
+                                + " EU capacity per Energy Hatch")
                 .addInfo("If the recipe has a startup cost greater than the")
                 .addInfo("number of energy hatches * cap, you can't do it")
+                .addInfo(
+                        "If the recipe requires a voltage tier over "
+                                + GT_Utility.getColoredTierNameFromTier((byte) tier())
+                                + EnumChatFormatting.GRAY
+                                + " , you can't do it either")
                 .addInfo("Make sure the whole structure is built in the 3x3")
                 .addInfo("chunk area of the ring center (not controller).").addInfo("Performs 4/4 overclock.")
                 .addInfo("Startup < 160,000,000 EU: 256x Parallel").addInfo("Startup < 320,000,000 EU: 192x Parallel")
@@ -80,13 +93,8 @@ public class LargeFusionComputer4 extends LargeFusionComputerPP {
     }
 
     @Override
-    public long maxEUStore() {
-        return 2560060000L * (Math.min(32, this.mEnergyHatches.size() + this.eEnergyMulti.size())) / 32L;
-    }
-
-    @Override
     public long capableStartupCanonical() {
-        return 2_560_060_000L;
+        return 5_120_000_000L;
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer4.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer4.java
@@ -46,10 +46,10 @@ public class LargeFusionComputer4 extends LargeFusionComputerPP {
         tt.addMachineType("Fusion Reactor").addInfo("Galaxy Collapse.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-IV Prototype.")
                 .addInfo(
-                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                        EnumChatFormatting.AQUA + GT_Utility.formatNumbers(getSingleHatchPower())
                                 + EnumChatFormatting.GRAY
-                                + "EU/t and "
-                                + EnumChatFormatting.BLUE
+                                + " EU/t and "
+                                + EnumChatFormatting.AQUA
                                 + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
                                 + "M"
                                 + EnumChatFormatting.GRAY

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer4.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer4.java
@@ -151,11 +151,6 @@ public class LargeFusionComputer4 extends LargeFusionComputerPP {
     }
 
     @Override
-    public int tierOverclock() {
-        return 8;
-    }
-
-    @Override
     public int extraPara(int startEnergy) {
         if (startEnergy < 160000000) return 4;
         if (startEnergy < 320000000) return 3;

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer5.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer5.java
@@ -151,11 +151,6 @@ public class LargeFusionComputer5 extends LargeFusionComputerPP {
     }
 
     @Override
-    public int tierOverclock() {
-        return 16;
-    }
-
-    @Override
     public int extraPara(int startEnergy) {
         if (startEnergy < 160000000) return 5;
         if (startEnergy < 320000000) return 4;

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer5.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer5.java
@@ -46,10 +46,10 @@ public class LargeFusionComputer5 extends LargeFusionComputerPP {
         tt.addMachineType("Fusion Reactor").addInfo("Galaxy Collapse.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-V.")
                 .addInfo(
-                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                        EnumChatFormatting.AQUA + GT_Utility.formatNumbers(getSingleHatchPower())
                                 + EnumChatFormatting.GRAY
-                                + "EU/t and "
-                                + EnumChatFormatting.BLUE
+                                + " EU/t and "
+                                + EnumChatFormatting.AQUA
                                 + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
                                 + "M"
                                 + EnumChatFormatting.GRAY

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer5.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeFusionComputer5.java
@@ -45,9 +45,22 @@ public class LargeFusionComputer5 extends LargeFusionComputerPP {
         final GT_Multiblock_Tooltip_Builder tt = new GT_Multiblock_Tooltip_Builder();
         tt.addMachineType("Fusion Reactor").addInfo("Galaxy Collapse.")
                 .addInfo("Controller block for the Compact Fusion Reactor MK-V.")
-                .addInfo("167,772,160EU/t and 320M EU capacity per Energy Hatch")
+                .addInfo(
+                        EnumChatFormatting.BLUE + GT_Utility.formatNumbers(getSingleHatchPower())
+                                + EnumChatFormatting.GRAY
+                                + "EU/t and "
+                                + EnumChatFormatting.BLUE
+                                + GT_Utility.formatNumbers(capableStartupCanonical() / 32 / M)
+                                + "M"
+                                + EnumChatFormatting.GRAY
+                                + " EU capacity per Energy Hatch")
                 .addInfo("If the recipe has a startup cost greater than the")
                 .addInfo("number of energy hatches * cap, you can't do it")
+                .addInfo(
+                        "If the recipe requires a voltage tier over "
+                                + GT_Utility.getColoredTierNameFromTier((byte) tier())
+                                + EnumChatFormatting.GRAY
+                                + " , you can't do it either")
                 .addInfo("Make sure the whole structure is built in the 3x3")
                 .addInfo("chunk area of the ring center (not controller).").addInfo("Performs 4/4 overclock.")
                 .addInfo("Startup < 160,000,000 EU: 320x Parallel").addInfo("Startup < 320,000,000 EU: 256x Parallel")
@@ -80,13 +93,8 @@ public class LargeFusionComputer5 extends LargeFusionComputerPP {
     }
 
     @Override
-    public long maxEUStore() {
-        return 10240800000L * (Math.min(32, this.mEnergyHatches.size() + this.eEnergyMulti.size())) / 32L;
-    }
-
-    @Override
     public long capableStartupCanonical() {
-        return 10_240_800_000L;
+        return 20_480_000_000L;
     }
 
     @Override

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -326,6 +326,7 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
                                             < this.mLastRecipe.mSpecialValue + this.lEUt) {
                                         mMaxProgresstime = 0;
                                         turnCasingActive(false);
+                                        criticalStopMachine();
                                     }
                                     getBaseMetaTileEntity().decreaseStoredEnergyUnits(
                                             this.mLastRecipe.mSpecialValue + this.lEUt,

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -69,6 +69,7 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
         implements IConstructable, ISurvivalConstructable, IOverclockDescriptionProvider {
 
     public static final String MAIN_NAME = "largeFusion";
+    public static final int M = 1_000_000;
     private boolean isLoadedChunk;
     public GT_Recipe mLastRecipe;
     public int para;
@@ -140,7 +141,9 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
     public abstract int tier();
 
     @Override
-    public abstract long maxEUStore();
+    public long maxEUStore() {
+        return capableStartupCanonical() * (Math.min(32, this.mEnergyHatches.size() + this.eEnergyMulti.size())) / 32L;
+    }
 
     /**
      * Unlike {@link #maxEUStore()}, this provides theoretical limit of startup EU, without considering the amount of
@@ -354,7 +357,7 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
      * @return The power one hatch can deliver to the reactor
      */
     protected long getSingleHatchPower() {
-        return 2048L * tierOverclock() * getMaxPara() * extraPara(100);
+        return GT_Values.V[tier()] * getMaxPara() * extraPara(100);
     }
 
     public boolean turnCasingActive(boolean status) {

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -356,7 +356,7 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
      * @return The power one hatch can deliver to the reactor
      */
     protected long getSingleHatchPower() {
-        return GT_Values.V[tier()] * getMaxPara() * extraPara(100);
+        return GT_Values.V[tier()] * getMaxPara() * extraPara(100) / 32;
     }
 
     public boolean turnCasingActive(boolean status) {

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputer.java
@@ -5,7 +5,6 @@ import static gregtech.api.enums.Textures.BlockIcons.*;
 import static gregtech.api.util.GT_StructureUtility.filterByMTETier;
 import static gregtech.api.util.GT_StructureUtility.ofFrame;
 import static gregtech.api.util.GT_Utility.filterValidMTEs;
-import static gregtech.api.util.GT_Utility.roundUpVoltage;
 
 import java.util.List;
 
@@ -409,27 +408,6 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
         mUpdate = 100;
     }
 
-    public abstract int tierOverclock();
-
-    public int overclock(int mStartEnergy) {
-        if (tierOverclock() == 1) {
-            return 0;
-        }
-        if (tierOverclock() == 2) {
-            return mStartEnergy <= 160000000 ? 1 : 0;
-        }
-        if (tierOverclock() == 4) {
-            return (mStartEnergy <= 160000000 ? 2 : (mStartEnergy <= 320000000 ? 1 : 0));
-        }
-        if (tierOverclock() == 8) {
-            return (mStartEnergy <= 160000000) ? 3
-                    : ((mStartEnergy <= 320000000) ? 2 : (mStartEnergy <= 640000000) ? 1 : 0);
-        }
-        return (mStartEnergy <= 160000000) ? 4
-                : ((mStartEnergy <= 320000000) ? 3
-                        : ((mStartEnergy <= 640000000) ? 2 : (mStartEnergy <= 1280000000) ? 1 : 0));
-    }
-
     @Override
     public RecipeMap<?> getRecipeMap() {
         return RecipeMaps.fusionRecipes;
@@ -454,19 +432,19 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
             @NotNull
             @Override
             protected GT_OverclockCalculator createOverclockCalculator(@NotNull GT_Recipe recipe) {
-                int overclockCount = overclock(recipe.mSpecialValue);
-                if (GT_Values.VP[LargeFusionComputer.this.tier()] <= roundUpVoltage(recipe.mEUt)) {
-                    overclockCount = 0;
-                }
-                return super.createOverclockCalculator(recipe).limitOverclockCount(overclockCount);
+                return overclockDescriber.createCalculator(super.createOverclockCalculator(recipe), recipe);
             }
 
             @NotNull
             @Override
             protected CheckRecipeResult validateRecipe(@NotNull GT_Recipe recipe) {
-                if (!mRunningOnLoad && recipe.mSpecialValue > maxEUStore()
-                        || GT_Values.VP[LargeFusionComputer.this.tier()] < recipe.mEUt) {
-                    return CheckRecipeResultRegistry.insufficientStartupPower(recipe.mSpecialValue);
+                if (!mRunningOnLoad) {
+                    if (recipe.mSpecialValue > maxEUStore()) {
+                        return CheckRecipeResultRegistry.insufficientStartupPower(recipe.mSpecialValue);
+                    }
+                    if (recipe.mEUt > GT_Values.V[tier()]) {
+                        return CheckRecipeResultRegistry.insufficientPower(recipe.mEUt);
+                    }
                 }
                 maxParallel = getMaxPara() * extraPara(recipe.mSpecialValue);
                 return CheckRecipeResultRegistry.SUCCESSFUL;
@@ -486,14 +464,13 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
                 para = getCurrentParallels();
                 return result;
             }
-        }.setOverclock(1, 1);
+        };
     }
 
     @Override
     protected void setProcessingLogicPower(ProcessingLogic logic) {
-        logic.setAvailableVoltage(GT_Values.V[hatchTier()]);
-        logic.setAvailableAmperage(
-                getSingleHatchPower() * (mEnergyHatches.size() + eEnergyMulti.size()) / GT_Values.V[hatchTier()]);
+        logic.setAvailableVoltage(GT_Values.V[tier()]);
+        logic.setAvailableAmperage(getSingleHatchPower() * 32 / GT_Values.V[tier()]);
     }
 
     @Override
@@ -554,11 +531,6 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
     }
 
     @Override
-    public boolean isGivingInformation() {
-        return true;
-    }
-
-    @Override
     public int getMaxEfficiency(ItemStack aStack) {
         return 10000;
     }
@@ -581,7 +553,7 @@ public abstract class LargeFusionComputer extends GT_MetaTileEntity_TooltipMulti
     @Override
     public String[] getInfoData() {
         IGregTechTileEntity baseMetaTileEntity = getBaseMetaTileEntity();
-        String tier = switch (hatchTier()) {
+        String tier = switch (tier()) {
             case 6 -> EnumChatFormatting.RED + "I" + EnumChatFormatting.RESET;
             case 7 -> EnumChatFormatting.RED + "II" + EnumChatFormatting.RESET;
             case 8 -> EnumChatFormatting.RED + "III" + EnumChatFormatting.RESET;

--- a/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputerPP.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/base/LargeFusionComputerPP.java
@@ -7,7 +7,8 @@ import com.github.technus.tectech.thing.metaTileEntity.multi.base.IStatusFunctio
 import com.github.technus.tectech.thing.metaTileEntity.multi.base.LedStatus;
 import com.github.technus.tectech.thing.metaTileEntity.multi.base.Parameters;
 
-import gregtech.api.logic.ProcessingLogic;
+import gregtech.api.objects.overclockdescriber.OverclockDescriber;
+import gregtech.api.util.AdvancedFusionOverclockDescriber;
 
 public abstract class LargeFusionComputerPP extends LargeFusionComputer {
 
@@ -29,14 +30,8 @@ public abstract class LargeFusionComputerPP extends LargeFusionComputer {
     }
 
     @Override
-    protected ProcessingLogic createProcessingLogic() {
-        return super.createProcessingLogic().setOverclock(2, 2);
-    }
-
-    @Override
-    protected long getSingleHatchPower() {
-        // Multiply by 8 so that we can have the original input power per hatch
-        return super.getSingleHatchPower() * 8;
+    protected OverclockDescriber createOverclockDescriber() {
+        return new AdvancedFusionOverclockDescriber((byte) tier(), capableStartupCanonical());
     }
 
     @Override


### PR DESCRIPTION
- Close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15568
- Adjust EU capacity and power restriction per energy hatch: 
- - For MK4 and MK5, EU capacity per hatch is doubled; now the maximum total energy capacities of compacts are the same as their small versions
- - The maximum input power (with 32 energy hatches) is just enough to run any recipe within their capabilities
- Compacts perform overclocks correctly with https://github.com/GTNewHorizons/GT5-Unofficial/pull/2528
- Compacts will assume there are always 32 energy hatches when they are processing recipes and calculating avaliable EUt. imo this will make them less confusing. (When machine fails you realize you should install more energy hatches for it)
- Tooltips changes 