### PR TITLE
Prevent LEG from drawing significantly higher amounts of coolant than expected

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
@@ -428,18 +428,12 @@ public class LargeEssentiaGenerator extends GT_MetaTileEntity_TooltipMultiBlockB
             for (Aspect aspect : aspects.aspects.keySet()) {
                 if (!isValidEssentia(aspect)) continue;
                 while (EUt <= (voltageLimit * ampLimit) && aspects.getAmount(aspect) > 0) {
-                    EUt += getPerAspectEnergy(aspect) * mStableValue / 25;
-                    if (EUt == 0) break;
+                    long addedEU = getPerAspectEnergy(aspect) * mStableValue / 25;
+                    if (addedEU == 0) break;
+                    EUt += addedEU;
                     aspects.reduce(aspect, 1);
                     if (aspects.getAmount(aspect) == 0) aspects.remove(aspect);
                 }
-            }
-            if (EUt == 0 && aspects.size() != 0) {
-                if (!isValidEssentia(aspects.getAspects()[0]) || getPerAspectEnergy(aspects.getAspects()[0]) == 0)
-                    continue;
-                EUt += getPerAspectEnergy(aspects.getAspects()[0]) * mStableValue / 25;
-                aspects.reduce(aspects.getAspects()[0], 1);
-                if (aspects.getAmount(aspects.getAspects()[0]) == 0) aspects.remove(aspects.getAspects()[0]);
             }
         }
 

--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
@@ -426,9 +426,10 @@ public class LargeEssentiaGenerator extends GT_MetaTileEntity_TooltipMultiBlockB
         for (EssentiaHatch hatch : this.mEssentiaHatch) {
             AspectList aspects = hatch.getAspects();
             for (Aspect aspect : aspects.aspects.keySet()) {
-                if (!isValidEssentia(aspect) || getPerAspectEnergy(aspect) == 0) continue;
+                if (!isValidEssentia(aspect)) continue;
                 while (EUt <= (voltageLimit * ampLimit) && aspects.getAmount(aspect) > 0) {
                     EUt += getPerAspectEnergy(aspect) * mStableValue / 25;
+                    if (EUt == 0) break;
                     aspects.reduce(aspect, 1);
                     if (aspects.getAmount(aspect) == 0) aspects.remove(aspect);
                 }


### PR DESCRIPTION
Fixes issue https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14104 by moving getPerAspectEnergy call into EU generation loop.


As an example, some sample data from supplying Ira with cryotheum as the coolant, over 60s+:

| Tier  | Expected Coolant Draw | Current Coolant Draw| This PR  |
|-------|:----------:|:---------:|--------|
| HV 4A | 0.9503 | 200.83  | 0.944  |
| EV 4A | 3.8014  |  203.27    | 3.8282 |

And with Adept hatches instead of novice:

| Tier  | Expected | Current | This PR |
|-------|----------|---------|-------|
| EV 4A | 1.907    |  200.42     | 1.99  |
| IV 4A | 7.6028   |   201.878      | 7.802 |