### PR TITLE
LEG rotation fix

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/LargeEssentiaGenerator.java
@@ -136,17 +136,6 @@ public class LargeEssentiaGenerator extends GT_MetaTileEntity_TooltipMultiBlockB
     }
 
     @Override
-    public boolean onWrenchRightClick(ForgeDirection side, ForgeDirection wrenchingSide, EntityPlayer aPlayer, float aX,
-            float aY, float aZ) {
-        if (wrenchingSide.offsetY != 0) return false;
-        if (getBaseMetaTileEntity().isValidFacing(wrenchingSide)) {
-            getBaseMetaTileEntity().setFrontFacing(wrenchingSide);
-            return true;
-        }
-        return false;
-    }
-
-    @Override
     public boolean onRightclick(IGregTechTileEntity aBaseMetaTileEntity, EntityPlayer aPlayer) {
         if (this.getBaseMetaTileEntity().isServerSide()) {
             ItemStack tCurrentItem = aPlayer.inventory.getCurrentItem();


### PR DESCRIPTION
Previously, the Large Essentia Generator could only be rotated to two possible orientations: either with the main structure below the controller (if the face of the controller was pointed towards any cardinal direction), or with the structure on the *south* side of the controller (if the face of the controller was pointing up or down). This was caused by the LEG attempting to do its own rotation logic (??) instead of inheriting the one from `GT_MetaTileEntity_EnhancedMultiblockBase` and reimplementing it poorly.

This PR makes it so that the LEG can be rotated to any direction, allowing for more varied and compact setups. Flipping the LEG is still allowed, although it makes no functional difference (since the structure is symmetrical).

![](https://i.imgur.com/25c8boN.png)