### PR TITLE
Make the Neutron Activator UI always report kinetic energy in MeV.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,12 +1,12 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.151:dev')
-    api('com.github.GTNewHorizons:bartworks:0.9.19:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.155:dev')
+    api('com.github.GTNewHorizons:bartworks:0.9.21:dev')
     implementation('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
-    implementation('com.github.GTNewHorizons:GTplusplus:1.11.53:dev')
+    implementation('com.github.GTNewHorizons:GTplusplus:1.11.57:dev')
 
-    compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.6.4-GTNH:dev') {transitive =  false}
+    compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.6.5-GTNH:dev') {transitive =  false}
 
     runtimeOnly('com.github.GTNewHorizons:Baubles:1.0.4:dev')
 }

--- a/src/main/java/goodgenerator/blocks/tileEntity/NeutronActivator.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/NeutronActivator.java
@@ -69,7 +69,12 @@ public class NeutronActivator extends GT_MetaTileEntity_TooltipMultiBlockBase_EM
     protected int height = 0;
     protected int eV = 0, mCeil = 0, mFloor = 0;
     private GT_Recipe lastRecipe;
-    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
+    protected static final NumberFormatMUI numberFormat;
+    static {
+        numberFormat = new NumberFormatMUI();
+        numberFormat.setMinimumFractionDigits(2);
+        numberFormat.setMaximumFractionDigits(2);
+    }
     final XSTR R = new XSTR();
 
     private static final IIconContainer textureFontOn = new Textures.BlockIcons.CustomIcon("icons/NeutronActivator_On");
@@ -451,7 +456,7 @@ public class NeutronActivator extends GT_MetaTileEntity_TooltipMultiBlockBase_EM
                         new TextWidget(StatCollector.translateToLocal("gui.NeutronActivator.0"))
                                 .setDefaultColor(COLOR_TEXT_WHITE.get()))
                 .widget(
-                        new TextWidget().setStringSupplier(() -> numberFormat.formatWithSuffix(eV) + "eV")
+                        new TextWidget().setStringSupplier(() -> numberFormat.format(eV / 1_000_000d) + " MeV")
                                 .setDefaultColor(COLOR_TEXT_WHITE.get())
                                 .setEnabled(widget -> getBaseMetaTileEntity().getErrorDisplayID() == 0))
                 .widget(new FakeSyncWidget.IntegerSyncer(() -> eV, val -> eV = val));


### PR DESCRIPTION
Previously, the Neutron Activator GUI would use the generic MUI number formatting function to report its kinetic energy in appropriate units (k, M, G) depending on the amount of KE stored. However, this has proven impractical at the high end of the scale: any amount of energy between 1e9 and 1.1e9 eV would simply be reported as "1 GeV". This is insufficient granularity for the player to know whether it is ready to run a recipe. For instance, the Naquadria-Rich Solution recipe needs the KE to be between 1,050 MeV and 1,100 MeV.

This PR makes the GUI always report the energy in MeV, as this is the unit used in all NEI diagrams and probably the most relevant one to the player.

![](https://i.imgur.com/BU0yzCO.png)