### PR TITLE
Fix Essentia Input Hatch

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/EssentiaHatch.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/EssentiaHatch.java
@@ -99,7 +99,7 @@ public class EssentiaHatch extends TileEntity implements IAspectContainer, IEsse
             if (te[i] != null) {
                 IEssentiaTransport pipe = (IEssentiaTransport) te[i];
                 if (!pipe.canOutputTo(ForgeDirection.VALID_DIRECTIONS[i])) {
-                    return;
+                    continue;
                 }
                 if ((pipe.getEssentiaType(ForgeDirection.VALID_DIRECTIONS[i].getOpposite()) != null)
                         && (pipe.getSuctionAmount(ForgeDirection.VALID_DIRECTIONS[i])


### PR DESCRIPTION
When the hatch ticks it checks around it for things that look like Thaumcraft pipes. Before this commit, if it happens that the first one it checks can't output to the hatch, it gives up instead of checking the others.

That behavior created weird bugs with two hatches adjacent, especially in the case where you have rotated the LEG, either with #249 or placing the controller facing up/down in the current release.