### PR TITLE
Prevent Instant UCFE Explosions

### DIFF
--- a/src/main/java/goodgenerator/blocks/tileEntity/UniversalChemicalFuelEngine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/UniversalChemicalFuelEngine.java
@@ -186,12 +186,13 @@ public class UniversalChemicalFuelEngine extends GT_MetaTileEntity_TooltipMultiB
         tt.addMachineType("Chemical Engine").addInfo("Controller block for the Chemical Engine")
                 .addInfo("BURNING BURNING BURNING").addInfo("Use combustible liquid to generate power.")
                 .addInfo("You need to supply Combustion Promoter to keep it running.")
-                .addInfo("This engine will consume all the fuel and combustion promoter in the hatch every second.")
-                .addInfo("If the energy hatch's buffer fills up, the machine will explode due to accumulated energy!")
-                .addInfo("When turned on, the engine goes through a 10-second starting period which prevents explosions.")
-                .addInfo("Even if an explosion is prevented due to excess fuel, all the fuel in the hatch will be voided.")
+                .addInfo("It will consume all the fuel and promoter in the hatch every second.")
+                .addInfo("If the energy hatch's buffer fills up, the machine will explode!")
+                .addInfo("When turned on, there's 10-second starting period which prevents explosions.")
+                .addInfo("Even if an explosion is prevented, all the fuel in the hatch will be voided.")
                 .addInfo("The efficiency is determined by the proportion of Combustion Promoter to fuel.")
                 .addInfo("The proportion is bigger, and the efficiency will be higher.")
+                .addInfo("Start machine with power button to force structure check.")
                 .addInfo("It creates sqrt(Current Output Power) pollution every second")
                 .addInfo(
                         "If you forget to supply Combustion Promoter, this engine will swallow all the fuel "
@@ -201,9 +202,10 @@ public class UniversalChemicalFuelEngine extends GT_MetaTileEntity_TooltipMultiB
                                 + ".")
                 .addInfo("The efficiency is up to 150%.").addInfo("The structure is too complex!")
                 .addInfo(BLUE_PRINT_INFO).addSeparator().beginStructureBlock(5, 4, 9, false)
-                .addMaintenanceHatch("Hint block with dot 1").addMufflerHatch("Hint block with dot 2 (fill all slots with mufflers)")
-                .addInputHatch("Hint block with dot 3 (fill all slots with input hatches)").addDynamoHatch("Hint block with dot 4")
-                .toolTipFinisher("Good Generator");
+                .addMaintenanceHatch("Hint block with dot 1")
+                .addMufflerHatch("Hint block with dot 2 (fill all slots with mufflers)")
+                .addInputHatch("Hint block with dot 3 (fill all slots with input hatches)")
+                .addDynamoHatch("Hint block with dot 4").toolTipFinisher("Good Generator");
         return tt;
     }
 
@@ -254,6 +256,7 @@ public class UniversalChemicalFuelEngine extends GT_MetaTileEntity_TooltipMultiB
         explosionSafetyTicks = 0;
         super.stopMachine();
     }
+
     @Override
     public boolean onRunningTick(ItemStack stack) {
         super.onRunningTick(stack);
@@ -262,8 +265,7 @@ public class UniversalChemicalFuelEngine extends GT_MetaTileEntity_TooltipMultiB
         if (explosionSafetyTicks < EXPLOSION_SAFETY_TIMER) {
             explosionSafetyTicks++;
             isExplosionSafe = true;
-        }
-        else if (isExplosionSafe) isExplosionSafe = false;
+        } else if (isExplosionSafe) isExplosionSafe = false;
 
         if (this.getBaseMetaTileEntity().isServerSide()) {
             addAutoEnergy();

--- a/src/main/java/goodgenerator/blocks/tileEntity/UniversalChemicalFuelEngine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/UniversalChemicalFuelEngine.java
@@ -9,6 +9,7 @@ import static gregtech.api.enums.Textures.BlockIcons.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import gregtech.api.enums.TickTime;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -55,7 +56,7 @@ public class UniversalChemicalFuelEngine extends GT_MetaTileEntity_TooltipMultiB
     protected final double GAS_EFFICIENCY_COEFFICIENT = 0.04D;
     protected final double ROCKET_EFFICIENCY_COEFFICIENT = 0.005D;
     protected final double EFFICIENCY_CEILING = 1.5D;
-    protected final int HEATING_TIMER = 200;
+    protected final int HEATING_TIMER = TickTime.SECOND * 10;
 
     private long tEff;
     private int heatingTicks;

--- a/src/main/java/goodgenerator/blocks/tileEntity/UniversalChemicalFuelEngine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/UniversalChemicalFuelEngine.java
@@ -9,7 +9,6 @@ import static gregtech.api.enums.Textures.BlockIcons.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import gregtech.api.enums.TickTime;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -30,6 +29,7 @@ import goodgenerator.loader.Loaders;
 import goodgenerator.util.DescTextLocalization;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_HatchElement;
+import gregtech.api.enums.TickTime;
 import gregtech.api.interfaces.ITexture;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;

--- a/src/main/java/goodgenerator/blocks/tileEntity/UniversalChemicalFuelEngine.java
+++ b/src/main/java/goodgenerator/blocks/tileEntity/UniversalChemicalFuelEngine.java
@@ -187,6 +187,9 @@ public class UniversalChemicalFuelEngine extends GT_MetaTileEntity_TooltipMultiB
                 .addInfo("BURNING BURNING BURNING").addInfo("Use combustible liquid to generate power.")
                 .addInfo("You need to supply Combustion Promoter to keep it running.")
                 .addInfo("This engine will consume all the fuel and combustion promoter in the hatch every second.")
+                .addInfo("If the energy hatch's buffer fills up, the machine will explode due to accumulated energy!")
+                .addInfo("When turned on, the engine goes through a 10-second starting period which prevents explosions.")
+                .addInfo("Even if an explosion is prevented due to excess fuel, all the fuel in the hatch will be voided.")
                 .addInfo("The efficiency is determined by the proportion of Combustion Promoter to fuel.")
                 .addInfo("The proportion is bigger, and the efficiency will be higher.")
                 .addInfo("It creates sqrt(Current Output Power) pollution every second")
@@ -198,8 +201,8 @@ public class UniversalChemicalFuelEngine extends GT_MetaTileEntity_TooltipMultiB
                                 + ".")
                 .addInfo("The efficiency is up to 150%.").addInfo("The structure is too complex!")
                 .addInfo(BLUE_PRINT_INFO).addSeparator().beginStructureBlock(5, 4, 9, false)
-                .addMaintenanceHatch("Hint block with dot 1").addMufflerHatch("Hint block with dot 2")
-                .addInputHatch("Hint block with dot 3").addDynamoHatch("Hint block with dot 4")
+                .addMaintenanceHatch("Hint block with dot 1").addMufflerHatch("Hint block with dot 2 (fill all slots with mufflers)")
+                .addInputHatch("Hint block with dot 3 (fill all slots with input hatches)").addDynamoHatch("Hint block with dot 4")
                 .toolTipFinisher("Good Generator");
         return tt;
     }
@@ -292,13 +295,19 @@ public class UniversalChemicalFuelEngine extends GT_MetaTileEntity_TooltipMultiB
             GT_MetaTileEntity_Hatch_Dynamo tHatch = mDynamoHatches.get(0);
             if (tHatch.maxEUOutput() * tHatch.maxAmperesOut() >= exEU) {
                 tHatch.setEUVar(Math.min(tHatch.maxEUStore(), tHatch.getBaseMetaTileEntity().getStoredEU() + exEU));
-            } else if (!isExplosionSafe) tHatch.doExplosion(tHatch.maxEUOutput());
+            } else if (!isExplosionSafe) {
+                tHatch.doExplosion(tHatch.maxEUOutput());
+                stopMachine();
+            }
         }
         if (!eDynamoMulti.isEmpty()) {
             GT_MetaTileEntity_Hatch_DynamoMulti tHatch = eDynamoMulti.get(0);
             if (tHatch.maxEUOutput() * tHatch.maxAmperesOut() >= exEU) {
                 tHatch.setEUVar(Math.min(tHatch.maxEUStore(), tHatch.getBaseMetaTileEntity().getStoredEU() + exEU));
-            } else if (!isExplosionSafe) tHatch.doExplosion(tHatch.maxEUOutput());
+            } else if (!isExplosionSafe) {
+                tHatch.doExplosion(tHatch.maxEUOutput());
+                stopMachine();
+            }
         }
     }
 


### PR DESCRIPTION
The Universal Chemical Fuel Engine is an LuV powergen multiblock that takes in fuel and Combustion Promoter, and consumes all that it finds in the input hatches every second. If it consumes more fuel and has nowhere to send the EU, because the dynamo's buffer, it explodes. This mechanic causes at least two problems:

- If the multi is turned on with some amount of fuel inside, from setting up the regulators and then powering on the UCFE after some time, it will instantly explode;
- On world load, if the EU is not drawn out fast enough, the UCFE will run until the buffer is full and just explode.

I added an explosion safety counter, which counts to 200 ticks (10 seconds). Every time the machine is turned off, or the world is reloaded, the counter goes back to 0. During these 10 seconds, the machine cannot explode, but any "excess" fuel provided to it will be voided while the protection is up. 

I also added some extra information to the tooltip, related to its structure, and the fact it does not check for a valid structure automatically: it has to be powered on to re-check the structure. I didn't want to attempt a fix for this in this PR, since the explosion bug is a problem that should be fixed in 2.6.1.